### PR TITLE
Frontend api fix

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -36,11 +36,24 @@ All API requests should be made to the following base URL (Spring Boot's default
 
 ### **Endpoints**
 
-- **Create Admin:** `POST /`
-    - **Parameters:**  
-        - `name` (string, required): The name of the new admin.  
-        - `email` (string, required): The email of the new admin.  
+- **Create Admin:** `POST /` 
     - **Description:** Creates a new admin in the system.
+    - **Request Body:**
+    ```json
+    {
+        "name": "Admin Name",
+        "email": "admin@example.com",
+        "password": "securepassword"
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "accountId": 1,
+        "userName": "Admin Name",
+        "userEmail": "admin@example.com"
+    }
+    ```
 
 - **Delete Admin:** `DELETE /{adminId}`
     - **Parameters:**
@@ -48,29 +61,90 @@ All API requests should be made to the following base URL (Spring Boot's default
     - **Description:** Removes an admin from the system permanently.
 
 - **Modify Admin Name:** `PUT /{adminId}/update-name`
-    - **Parameters:**  
-        - `newName` (string, required): The updated name for the admin.  
+    - **Request Body:**
+    ```json
+    {
+        "newName": "Updated Admin Name"
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "accountId": 1,
+        "userName": "Updated Admin Name",
+        "userEmail": "admin@example.com"
+    }
+    ```
     - **Description:** Updates the admin's **name** field in the database.
 
 - **Modify Admin Email:** `PUT /{adminId}/update-email`
-    - **Parameters:**  
-        - `newEmail` (string, required): The updated email for the admin.  
+    - **Request Body:**
+    ```json
+    {
+        "newEmail": "updated.admin@example.com"
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "accountId": 1,
+        "userName": "Admin Name",
+        "userEmail": "updated.admin@example.com"
+    }
+    ``` 
     - **Description:** Updates the admin's **email** field in the database.
 
 - **Create Team Member:** `POST /team-member`
-    - **Parameters:**  
-        - `name` (string, required): The name of the new team member.  
-        - `email` (string, required): The email of the new team member.  
+    - **Request Body:**
+    ```json
+    {
+        "name": "Team Member",
+        "email": "teammember@example.com",
+        "password": "securepassword"
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "accountId": 2,
+        "userName": "Team Member",
+        "userEmail": "teammember@example.com"
+    }
+    ```
     - **Description:** Adds a new team member to the system.
 
 - **Modify Team Member Name:** `PUT /team-member/{teamMemberId}/update-name`
-    - **Parameters:**  
-        - `newName` (string, required): The updated name for the team member.  
+    - **Request Body:**
+    ```json
+    {
+        "newName": "Updated Team Member"
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "accountId": 2,
+        "userName": "Updated Team Member",
+        "userEmail": "teammember@example.com"
+    }
+    ```
     - **Description:** Updates the **name** field of the specified team member in the database.
 
 - **Modify Team Member Email:** `PUT /team-member/{teamMemberId}/update-email`
-    - **Parameters:**  
-        - `newEmail` (string, required): The updated email for the team member.  
+    - **Request Body:**
+    ```json
+    {
+        "newEmail": "updated.tm@example.com"
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "accountId": 2,
+        "userName": "Team Member",
+        "userEmail": "updated.tm@example.com"
+    }
+    ```
     - **Description:** Updates the **email** field of the specified team member in the database.
 
 - **Delete Team Member:** `DELETE /team-member/{teamMemberId}`

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -275,6 +275,21 @@ All API requests should be made to the following base URL (Spring Boot's default
     - **Description:** Updates the team lead for a specified team by assigning a different team member.
 
 - **Get Team Members:** `GET /{teamId}/members`
+    - **Response Body:**
+    ```json
+    [
+        {
+            "accountId": 1,
+            "userName": "John Doe",
+            "userEmail": "john@example.com"
+        },
+        {
+            "accountId": 2,
+            "userName": "Jane Smith",
+            "userEmail": "jane@example.com"
+        }
+    ]
+    ```
     - **Description:** Returns a list of every team member in a team. Each list item contains the team member's ID, name, and email.
 
 ---
@@ -285,37 +300,79 @@ All API requests should be made to the following base URL (Spring Boot's default
 
 ### Endpoints
 - **Create a Task:** `POST`
-    - **Parameters:**:
-        - `title` (string, required): The title of the new task.
-        - `description` (string, optional): A description of the task.
-        - `isLocked` (boolean, optional): Whether the task is locked (`true`) or unlocked (`false`). Defaults to `null` if not provided.
-        - `status` (string, optional): The status of the task (e.g., "To-Do", "In Progress", "Done"). Defaults to `null` if not provided.
-        - `teamId` (integer, required): The ID of the team being assigned to the task.
+    - **Request Body:**
+    ```json
+    {
+        "title": "Task Title",
+        "description": "Task Description",
+        "isLocked": false,
+        "status": "To-Do",
+        "dueDate": "2025-03-01",
+        "teamId": 3
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "taskId": 4,
+        "title": "Task Title",
+        "description": "Task Description",
+        "isLocked": false,
+        "status": "To-Do",
+        "dueDate": "2025-03-01",
+        "teamId": 3
+    }
+    ```
+    - **Description:** Creates a task in the database.
 
 - **Delete a Task:** `DELETE /{taskId}`
     - **Description:** Deletes a task from the database.
 
 - **Edit a Task:** `PUT /{taskId}`
-    - **Description:** Updates the details of a task.
     - **Request Body:** (TaskDTO, JSON)
     ```json
     {
-        "title": "New Task Title",
+        "title": "Updated Title",
         "description": "Updated Description",
         "isLocked": false,
         "status": "In Progress",
-        "dueDate": "2025-03-01"
+        "dueDate": "2025-04-01"
     }
     ```
-    - **Note:** Only the provided fields will be updated. Missing fields will remain the same.
+    - **Response Body:**
+    ```json
+    {
+        "taskId": 4,
+        "title": "Updated Title",
+        "description": "Updated Description",
+        "isLocked": false,
+        "status": "In Progress",
+        "dueDate": "2025-04-01",
+        "teamId": 3
+    }
+    ```
+    - **Description:** Updates the details of a task.
 
 - **Assign Member to a Task:** `POST /{taskId}/assign/{teamMemberId}`
+    - **Response Body:**
+    ```json
+    {
+        "isAssignedId": 1,
+        "taskId": 4,
+        "teamMemberId": 2,
+        "teamId": 3
+    }
+    ```
     - **Description:** Assigns a member (admin or team member) to a task.
 
 - **Change Password:** `POST /team-members/{teamMemberId}/change-password`
-    - **Parameters:**
-        - `oldPassword` (string, required): The current password of the user.
-        - `newPassword` (string, optional): The new password of the user.
+    - **Request Body:**
+    ```json
+    {
+        "oldPassword": "oldPass123",
+        "newPassword": "newPass456"
+    }
+    ```
     - **Description:** Updates the password field for a team member.
 
 ---

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -234,18 +234,44 @@ All API requests should be made to the following base URL (Spring Boot's default
 
 ### Endpoints
 - **Create a Team:** `POST`
-    - **Parameters:**: 
-        - `teamName` (string, required): The name of the new team.
-        - `teamLeadId` (integer, required): The ID of the team lead of the new team.
-            - This parameter **must be included** in the request, but it can be set to `null` if no team lead is assigned.
+    - **Request Body:**
+    ```json
+    {
+        "teamId": 1, 
+        "teamName": "Development Team",
+        "teamLeadId": 1001
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "teamId": 1,
+        "teamName": "Development Team",
+        "teamLeadId": 1001
+    }
+    ```
     - **Description:** Creates a team in the database.
 
 - **Delete a Team:** `DELETE /{teamId}`
     - **Description:** Deletes a team from the database.
     
 - **Change Team Lead:** `PUT /{teamId}/change-lead`
-    - **Parameters:**: 
-        - `teamLeadId` (integer, required): The ID of the team member that is becoming the team lead.
+    - **Request Body:**
+    ```json
+    {
+        "teamId": 1,
+        "teamName": "Updated Team Name",
+        "teamLeadId": 1002
+    }
+    ```
+    - **Response Body:**
+    ```json
+    {
+        "teamId": 1,
+        "teamName": "Updated Team Name",
+        "teamLeadId": 1002
+    }
+    ```
     - **Description:** Updates the team lead for a specified team by assigning a different team member.
 
 - **Get Team Members:** `GET /{teamId}/members`

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/AdminRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/AdminRequestDTO.java
@@ -7,9 +7,10 @@ public class AdminRequestDTO {
 
     public AdminRequestDTO() {}
 
-    public AdminRequestDTO(String name, String email) {
+    public AdminRequestDTO(String name, String email, String password) {
         this.name = name;
         this.email = email;
+        this.password = password;
     }
 
     public String getName() {

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/AdminRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/AdminRequestDTO.java
@@ -1,0 +1,39 @@
+package com.example.task_manager.DTO;
+
+public class AdminRequestDTO {
+    private String name;
+    private String email;
+    private String password;
+
+    public AdminRequestDTO() {}
+
+    public AdminRequestDTO(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+}

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/PasswordChangeRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/PasswordChangeRequestDTO.java
@@ -1,0 +1,39 @@
+package com.example.task_manager.DTO;
+
+public class PasswordChangeRequestDTO {
+    private int teamMemberId;
+    private String oldPassword;
+    private String newPassword;
+
+    public PasswordChangeRequestDTO() {}
+
+    public PasswordChangeRequestDTO(int teamMemberId, String oldPassword, String newPassword) {
+        this.teamMemberId = teamMemberId;
+        this.oldPassword = oldPassword;
+        this.newPassword = newPassword;
+    }
+
+    public String getOldPassword() {
+        return oldPassword;
+    }
+
+    public void setOldPassword(String oldPassword) {
+        this.oldPassword = oldPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public int getTeamMemberId() {
+        return teamMemberId;
+    }
+
+    public void setTeamMemberId(int teamMemberId) {
+        this.teamMemberId = teamMemberId;
+    }
+}

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/TaskDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/TaskDTO.java
@@ -6,14 +6,14 @@ public class TaskDTO {
     private int taskId;
     private String title;
     private String description;
-    private Boolean isLocked;
+    private boolean isLocked;
     private String status;
     private LocalDate dueDate;
     private int teamId;
 
     public TaskDTO() {}
 
-    public TaskDTO(int taskId, String title, String description, Boolean isLocked, String status, LocalDate dueDate, int teamId) {
+    public TaskDTO(int taskId, String title, String description, boolean isLocked, String status, LocalDate dueDate, int teamId) {
         this.taskId = taskId;
         this.title = title;
         this.description = description;
@@ -48,11 +48,11 @@ public class TaskDTO {
         this.description = description;
     }
 
-    public Boolean getIsLocked() {
+    public boolean getIsLocked() {
         return isLocked;
     }
 
-    public void setLocked(Boolean isLocked) {
+    public void setLocked(boolean isLocked) {
         this.isLocked = isLocked;
     }
 

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/TaskRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/TaskRequestDTO.java
@@ -1,6 +1,7 @@
 package com.example.task_manager.DTO;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class TaskRequestDTO {
     private String title;
@@ -8,12 +9,12 @@ public class TaskRequestDTO {
     private Boolean isLocked;
     private String status;
     private LocalDate dueDate;
-    private Integer assignedTo;
+    private List<Integer> assignedTo;
     private Integer teamId;
 
     public TaskRequestDTO() {}
 
-    public TaskRequestDTO(String title, String description, Boolean isLocked, String status, LocalDate dueDate, Integer assignedTo, Integer teamId) {
+    public TaskRequestDTO(String title, String description, Boolean isLocked, String status, LocalDate dueDate, List<Integer> assignedTo, Integer teamId) {
         this.title = title;
         this.description = description;
         this.isLocked = isLocked;
@@ -55,11 +56,11 @@ public class TaskRequestDTO {
         this.dueDate = dueDate;
     }
 
-    public Integer getAssignedTo() {
+    public List<Integer> getAssignedTo() {
         return assignedTo;
     }
 
-    public void setAssignedTo(Integer assignedTo) {
+    public void setAssignedTo(List<Integer> assignedTo) {
         this.assignedTo = assignedTo;
     }
 

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/TaskRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/TaskRequestDTO.java
@@ -2,34 +2,25 @@ package com.example.task_manager.DTO;
 
 import java.time.LocalDate;
 
-public class TaskDTO {
-    private int taskId;
+public class TaskRequestDTO {
     private String title;
     private String description;
     private Boolean isLocked;
     private String status;
     private LocalDate dueDate;
-    private int teamId;
+    private Integer assignedTo;
+    private Integer teamId;
 
-    public TaskDTO() {}
+    public TaskRequestDTO() {}
 
-    public TaskDTO(int taskId, String title, String description, Boolean isLocked, String status, LocalDate dueDate, int teamId) {
-        this.taskId = taskId;
+    public TaskRequestDTO(String title, String description, Boolean isLocked, String status, LocalDate dueDate, Integer assignedTo, Integer teamId) {
         this.title = title;
         this.description = description;
         this.isLocked = isLocked;
         this.status = status;
         this.dueDate = dueDate;
+        this.assignedTo = assignedTo;
         this.teamId = teamId;
-    }
-
-    //getters and setters
-    public int getTaskId() {
-        return taskId;
-    }
-
-    public void setTaskId(int taskId) {
-        this.taskId = taskId;
     }
 
     public String getTitle() {
@@ -52,16 +43,8 @@ public class TaskDTO {
         return isLocked;
     }
 
-    public void setLocked(Boolean isLocked) {
+    public void setIsLocked(Boolean isLocked) {
         this.isLocked = isLocked;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
     }
 
     public LocalDate getDueDate() {
@@ -72,11 +55,27 @@ public class TaskDTO {
         this.dueDate = dueDate;
     }
 
-    public int getTeamId() {
+    public Integer getAssignedTo() {
+        return assignedTo;
+    }
+
+    public void setAssignedTo(Integer assignedTo) {
+        this.assignedTo = assignedTo;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getTeamId() {
         return teamId;
     }
 
-    public void setTeamId(int teamId) {
+    public void setTeamId(Integer teamId) {
         this.teamId = teamId;
     }
 }

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/TeamRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/TeamRequestDTO.java
@@ -1,0 +1,40 @@
+package com.example.task_manager.DTO;
+
+public class TeamRequestDTO {
+    private int teamId;
+    private String teamName;
+    private int teamLeadId;
+    
+    public TeamRequestDTO() {
+    }
+
+    public TeamRequestDTO(int teamId, String teamName, int teamLeadId) {
+        this.teamId = teamId;
+        this.teamName = teamName;
+        this.teamLeadId = teamLeadId;
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public void setTeamName(String teamName) {
+        this.teamName = teamName;
+    }
+
+    public int getTeamLeadId() {
+        return teamLeadId;
+    }
+
+    public void setTeamLeadId(int teamLeadId) {
+        this.teamLeadId = teamLeadId;
+    }
+
+    public int getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(int teamId) {
+        this.teamId = teamId;
+    }
+}

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/UpdateEmailRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/UpdateEmailRequestDTO.java
@@ -1,0 +1,20 @@
+package com.example.task_manager.DTO;
+
+public class UpdateEmailRequestDTO {
+    private String newEmail;
+
+    public UpdateEmailRequestDTO() {
+    }
+    
+    public UpdateEmailRequestDTO(String newEmail) {
+        this.newEmail = newEmail;
+    }
+
+    public String getNewEmail() {
+        return newEmail;
+    }
+
+    public void setNewEmail(String newEmail) {
+        this.newEmail = newEmail;
+    }
+}

--- a/backend/task-manager/src/main/java/com/example/task_manager/DTO/UpdateNameRequestDTO.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/DTO/UpdateNameRequestDTO.java
@@ -1,0 +1,20 @@
+package com.example.task_manager.DTO;
+
+public class UpdateNameRequestDTO {
+    private String newName;
+
+    public UpdateNameRequestDTO() {
+    }
+    
+    public UpdateNameRequestDTO(String newName) {
+        this.newName = newName;
+    }
+
+    public String getNewName() {
+        return newName;
+    }
+
+    public void setNewName(String newName) {
+        this.newName = newName;
+    }
+}

--- a/backend/task-manager/src/main/java/com/example/task_manager/controller/AdminController.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/controller/AdminController.java
@@ -1,9 +1,16 @@
 package com.example.task_manager.controller;
 
+import com.example.task_manager.DTO.AdminDTO;
+import com.example.task_manager.DTO.AdminRequestDTO;
+import com.example.task_manager.DTO.UpdateNameRequestDTO;
 import com.example.task_manager.service.AdminService;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.NoSuchElementException;
+
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestController
 @RequestMapping("/api/admin")
@@ -18,12 +25,17 @@ public class AdminController {
 
     // Create Admin entity
     @PostMapping
-    public ResponseEntity<?> createAdmin(@RequestParam String name, @RequestParam String email, @RequestParam String userPassword) {
+    public ResponseEntity<AdminDTO> createAdmin(@RequestBody AdminRequestDTO request) {
         try {
-            return ResponseEntity.ok(adminService.createAdmin(name, email, userPassword));
+            AdminDTO createAdmin = adminService.createAdmin(
+                request.getName(),
+                request.getEmail(),
+                request.getPassword()
+            );
+            return ResponseEntity.ok(createAdmin);
         } 
         catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            return ResponseEntity.badRequest().body(null);
         }
     }
 
@@ -41,9 +53,10 @@ public class AdminController {
 
     // Modify Admin Name
     @PutMapping("/{adminId}/update-name")
-    public ResponseEntity<?> updateAdminName(@PathVariable int adminId, @RequestParam String newName) {
+    public ResponseEntity<?> updateAdminName(@PathVariable int adminId, @RequestBody UpdateNameRequestDTO request) {
         try {
-            return ResponseEntity.ok(adminService.modifyAdminName(adminId, newName));
+            AdminDTO updatedAdmin = adminService.modifyAdminName(adminId, request.getNewName());
+            return ResponseEntity.ok(updatedAdmin);
         } 
         catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());

--- a/backend/task-manager/src/main/java/com/example/task_manager/controller/AdminController.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/controller/AdminController.java
@@ -2,6 +2,8 @@ package com.example.task_manager.controller;
 
 import com.example.task_manager.DTO.AdminDTO;
 import com.example.task_manager.DTO.AdminRequestDTO;
+import com.example.task_manager.DTO.TeamMemberDTO;
+import com.example.task_manager.DTO.UpdateEmailRequestDTO;
 import com.example.task_manager.DTO.UpdateNameRequestDTO;
 import com.example.task_manager.service.AdminService;
 
@@ -25,7 +27,7 @@ public class AdminController {
 
     // Create Admin entity
     @PostMapping
-    public ResponseEntity<AdminDTO> createAdmin(@RequestBody AdminRequestDTO request) {
+    public ResponseEntity<?> createAdmin(@RequestBody AdminRequestDTO request) {
         try {
             AdminDTO createAdmin = adminService.createAdmin(
                 request.getName(),
@@ -35,7 +37,7 @@ public class AdminController {
             return ResponseEntity.ok(createAdmin);
         } 
         catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(null);
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 
@@ -65,9 +67,10 @@ public class AdminController {
 
     // Modify Admin Email
     @PutMapping("/{adminId}/update-email")
-    public ResponseEntity<?> updateAdminEmail(@PathVariable int adminId, @RequestParam String newEmail) {
+    public ResponseEntity<?> updateAdminEmail(@PathVariable int adminId, @RequestBody UpdateEmailRequestDTO request) {
         try {
-            return ResponseEntity.ok(adminService.modifyAdminEmail(adminId, newEmail));
+            AdminDTO updatedAdmin = adminService.modifyAdminEmail(adminId, request.getNewEmail());
+            return ResponseEntity.ok(updatedAdmin);
         }
         catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body("Admin not found");
@@ -79,9 +82,14 @@ public class AdminController {
 
     // Create Team Member
     @PostMapping("/team-member")
-    public ResponseEntity<?> createTeamMember(@RequestParam String name, @RequestParam String email, @RequestParam String userPassword) {
+    public ResponseEntity<?> createTeamMember(@RequestBody AdminRequestDTO request) {
         try {
-            return ResponseEntity.ok(adminService.createTeamMember(name, email, userPassword));
+            TeamMemberDTO createTeamMember = adminService.createTeamMember(
+                request.getName(),
+                request.getEmail(),
+                request.getPassword()
+            );
+            return ResponseEntity.ok(createTeamMember);
         } 
         catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -90,9 +98,9 @@ public class AdminController {
 
     // Modify Team Member Name
     @PutMapping("/team-member/{teamMemberId}/update-name")
-    public ResponseEntity<?> modifyTeamMemberName(@PathVariable int teamMemberId, @RequestParam String newName) {
+    public ResponseEntity<?> modifyTeamMemberName(@PathVariable int teamMemberId, @RequestBody UpdateNameRequestDTO request) {
         try {
-            return ResponseEntity.ok(adminService.modifyTeamMemberName(teamMemberId, newName));
+            return ResponseEntity.ok(adminService.modifyTeamMemberName(teamMemberId, request.getNewName()));
         }
         catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -101,9 +109,9 @@ public class AdminController {
 
     // Modify Team Member Email
     @PutMapping("/team-member/{teamMemberId}/update-email")
-    public ResponseEntity<?> modifyTeamMemberEmail(@PathVariable int teamMemberId, @RequestParam String newEmail) {
+    public ResponseEntity<?> modifyTeamMemberEmail(@PathVariable int teamMemberId, @RequestBody UpdateEmailRequestDTO request) {
         try {
-            return ResponseEntity.ok(adminService.modifyTeamMemberEmail(teamMemberId, newEmail));
+            return ResponseEntity.ok(adminService.modifyTeamMemberEmail(teamMemberId, request.getNewEmail()));
         } 
         catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body("Team member not found");

--- a/backend/task-manager/src/main/java/com/example/task_manager/controller/TeamController.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/controller/TeamController.java
@@ -2,6 +2,7 @@ package com.example.task_manager.controller;
 
 import com.example.task_manager.DTO.TeamDTO;
 import com.example.task_manager.DTO.TeamMemberDTO;
+import com.example.task_manager.DTO.TeamRequestDTO;
 import com.example.task_manager.service.TeamService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,9 +20,9 @@ public class TeamController {
 
     // Create a Team
     @PostMapping
-    public ResponseEntity<?> createTeam(@RequestParam String teamName, @RequestParam int teamLeadId) {
+    public ResponseEntity<?> createTeam(@RequestBody TeamRequestDTO request) {
         try {
-            TeamDTO team = teamService.createTeam(teamName, teamLeadId);
+            TeamDTO team = teamService.createTeam(request.getTeamName(), request.getTeamLeadId());
             return ResponseEntity.ok(team);
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -41,10 +42,10 @@ public class TeamController {
 
     // Change Team Lead
     @PutMapping("/{teamId}/change-lead")
-    public ResponseEntity<?> changeTeamLead(@PathVariable int teamId, @RequestParam int teamLeadId) {
+    public ResponseEntity<?> changeTeamLead(@PathVariable int teamId, @RequestBody TeamRequestDTO request) {
         try {
-            teamService.changeTeamLead(teamId, teamLeadId);
-            return ResponseEntity.ok().build();
+            TeamDTO updatedTeam = teamService.changeTeamLead(teamId, request.getTeamName(), request.getTeamLeadId());
+            return ResponseEntity.ok(updatedTeam);
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }

--- a/backend/task-manager/src/main/java/com/example/task_manager/controller/TeamMemberController.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/controller/TeamMemberController.java
@@ -7,7 +7,6 @@ import com.example.task_manager.DTO.TaskRequestDTO;
 import com.example.task_manager.service.TeamMemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/tasks")

--- a/backend/task-manager/src/main/java/com/example/task_manager/controller/TeamMemberController.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/controller/TeamMemberController.java
@@ -1,7 +1,9 @@
 package com.example.task_manager.controller;
 
 import com.example.task_manager.DTO.IsAssignedDTO;
+import com.example.task_manager.DTO.PasswordChangeRequestDTO;
 import com.example.task_manager.DTO.TaskDTO;
+import com.example.task_manager.DTO.TaskRequestDTO;
 import com.example.task_manager.service.TeamMemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,13 +21,9 @@ public class TeamMemberController {
 
     // Create a Task
     @PostMapping
-    public ResponseEntity<?> createTask(@RequestParam String title,
-                                        @RequestParam String description,
-                                        @RequestParam Boolean isLocked,
-                                        @RequestParam String status,
-                                        @RequestParam int teamId) {
+    public ResponseEntity<?> createTask(@RequestBody TaskRequestDTO request) {
         try {
-            TaskDTO task = teamMemberService.createTask(title, description, isLocked, status, LocalDate.now(), LocalDate.now(), null, null);
+            TaskDTO task = teamMemberService.createTask(request);
             return ResponseEntity.ok(task);
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -48,16 +46,8 @@ public class TeamMemberController {
     public ResponseEntity<?> editTask(@PathVariable int taskId,
                                     @RequestBody TaskDTO taskDTO) {
         try {
-            TaskDTO task = teamMemberService.editTask(
-                taskId,
-                taskDTO.getTitle(),
-                taskDTO.getDescription(),
-                taskDTO.isLocked(),
-                taskDTO.getStatus(),
-                null,
-                taskDTO.getDueDate()
-            );
-            return ResponseEntity.ok(task);
+            TaskDTO updatedTask = teamMemberService.editTask(taskId, taskDTO);
+            return ResponseEntity.ok(updatedTask);
         } 
         catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -78,10 +68,9 @@ public class TeamMemberController {
     // Change Password (Placeholder)
     @PostMapping("/team-members/{teamMemberId}/change-password")
     public ResponseEntity<?> changePassword(@PathVariable int teamMemberId,
-                                            @RequestParam String oldPassword,
-                                            @RequestParam String newPassword) {
+                                            @RequestBody PasswordChangeRequestDTO request) {
         try {
-            teamMemberService.changePassword(teamMemberId, oldPassword, newPassword);
+            teamMemberService.changePassword(teamMemberId, request.getOldPassword(), request.getNewPassword());
             return ResponseEntity.noContent().build();
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
@@ -2,13 +2,13 @@ package com.example.task_manager.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import com.example.task_manager.DTO.IsAssignedDTO;
 import com.example.task_manager.DTO.TaskDTO;
+import com.example.task_manager.DTO.TaskRequestDTO;
 import com.example.task_manager.DTO.TeamMemberDTO;
 import com.example.task_manager.entity.IsAssigned;
 import com.example.task_manager.entity.Task;
@@ -62,33 +62,28 @@ public class TeamMemberService {
 	 * @param assignedMembers       The set of assigned members (nullable).
 	 * @return The created Task entity.
 	 */
-	public TaskDTO createTask(String title, String description, Boolean isLocked, String status, 
-						   LocalDate expectedCompletionDate, LocalDate dueDate, Team team, 
-						   Set<IsAssigned> assignedMembers) {
+	public TaskDTO createTask(TaskRequestDTO request) {
 
-		if (title == null || title.trim().isEmpty()) {
+		if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
 			throw new RuntimeException("Task title cannot be null or empty");
 		}
 	
-		if (team == null) {
-			throw new RuntimeException("Task must be assigned to a team");
-		}
+		Team team = teamRepository.findById(request.getTeamId())
+			.orElseThrow(() -> new RuntimeException("Task must be assigned to a valid team"));
+
 
 		Task task = new Task();
-		task.setTitle(title);
-		task.setIsLocked(isLocked);
-		task.setStatus(status);
+		task.setTitle(request.getTitle());
+		task.setIsLocked(request.getIsLocked());
+		task.setStatus(request.getStatus());
 		task.setDateCreated(LocalDate.now());
 		task.setTeam(team);
 
-		if (description != null) {
-			task.setDescription(description);
+		if (request.getDescription() != null) {
+			task.setDescription(request.getDescription());
 		}
-		if (expectedCompletionDate != null) {
-			task.setExpectedCompletionDate(expectedCompletionDate);
-		}
-		if (dueDate != null) {
-			task.setDueDate(dueDate);
+		if (request.getDueDate() != null) {
+			task.setExpectedCompletionDate(request.getDueDate());
 		}
 
 		task = taskRepository.save(task);
@@ -124,28 +119,24 @@ public class TeamMemberService {
 	 * @param newDueDate            The new due date (nullable).
 	 * @return The updated Task entity.
 	 */
-	public TaskDTO editTask(int taskId, String newTitle, String newDescription, Boolean isLocked, 
-						 String newStatus, LocalDate newExpectedCompletionDate, LocalDate newDueDate) {
+	public TaskDTO editTask(int taskId, TaskDTO taskDTO) {
 		Task task = taskRepository.findById(taskId)
 			.orElseThrow(() -> new RuntimeException("Task not found with ID: " + taskId));
 	
-		if (newTitle != null && !newTitle.isEmpty()) {
-			task.setTitle(newTitle);
+		if (taskDTO.getTitle() != null && !taskDTO.getTitle().isEmpty()) {
+			task.setTitle(taskDTO.getTitle());
 		}
-		if (newDescription != null && !newDescription.isEmpty()) {
-			task.setDescription(newDescription);
+		if (taskDTO.getDescription() != null && !taskDTO.getDescription().isEmpty()) {
+			task.setDescription(taskDTO.getDescription());
 		}
-		if (isLocked != null) {
-			task.setIsLocked(isLocked);
+		if (taskDTO.getIsLocked() != null) {
+			task.setIsLocked(taskDTO.getIsLocked());
 		}
-		if (newStatus != null && !newStatus.isEmpty()) {
-			task.setStatus(newStatus);
+		if (taskDTO.getStatus() != null && !taskDTO.getStatus().isEmpty()) {
+			task.setStatus(taskDTO.getStatus());
 		}
-		if (newExpectedCompletionDate != null) {
-			task.setExpectedCompletionDate(newExpectedCompletionDate);
-		}
-		if (newDueDate != null) {
-			task.setDueDate(newDueDate);
+		if (taskDTO.getDueDate() != null) {
+			task.setDueDate(taskDTO.getDueDate());
 		}
 
 		task = taskRepository.save(task);

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
@@ -134,9 +134,9 @@ public class TeamMemberService {
 		if (taskDTO.getDescription() != null && !taskDTO.getDescription().isEmpty()) {
 			task.setDescription(taskDTO.getDescription());
 		}
-		if (taskDTO.getIsLocked() != null) {
-			task.setIsLocked(taskDTO.getIsLocked());
-		}
+		
+		task.setIsLocked(taskDTO.getIsLocked());
+		
 		if (taskDTO.getStatus() != null && !taskDTO.getStatus().isEmpty()) {
 			task.setStatus(taskDTO.getStatus());
 		}

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
@@ -67,6 +67,10 @@ public class TeamMemberService {
 		if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
 			throw new RuntimeException("Task title cannot be null or empty");
 		}
+
+		if (request.getTeamId() == null) {
+			throw new RuntimeException("Task must be assigned to a team");
+		}
 	
 		Team team = teamRepository.findById(request.getTeamId())
 			.orElseThrow(() -> new RuntimeException("Task must be assigned to a valid team"));

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamService.java
@@ -74,7 +74,7 @@ public class TeamService {
 	 * @param teamId The ID of the team whose lead should be changed.
 	 * @param teamLeadId The ID of the new team lead.
 	 */
-	public void changeTeamLead(int teamId, int teamLeadId) {
+	public TeamDTO changeTeamLead(int teamId, String teamName, int teamLeadId) {
 		Team team = teamRepository.findById(teamId)
 				.orElseThrow(() -> new RuntimeException("Team not found with ID: " + teamId));
 
@@ -82,7 +82,10 @@ public class TeamService {
 				.orElseThrow(() -> new RuntimeException("Team Lead not found with ID: " + teamLeadId));
 
 		team.setTeamLead(teamMember);
+		team.setTeamName(teamName);
 		teamRepository.save(team);
+
+		return new TeamDTO(team.getTeamId(), team.getTeamName(), team.getTeamLead().getAccountId());
 	}
 
 	/**

--- a/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/AdminRequestDTOTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/AdminRequestDTOTest.java
@@ -1,0 +1,35 @@
+package com.example.task_manager.DTO_tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.task_manager.DTO.AdminRequestDTO;
+
+public class AdminRequestDTOTest {
+    @Test
+    void testAdminRequestDTOConstructorAndGetters() {
+        String expectedName = "Admin User";
+        String expectedEmail = "admin@example.com";
+        String expectedPassword = "securepassword";
+
+        AdminRequestDTO adminRequestDTO = new AdminRequestDTO(expectedName, expectedEmail, expectedPassword);
+
+        assertEquals(expectedName, adminRequestDTO.getName());
+        assertEquals(expectedEmail, adminRequestDTO.getEmail());
+        assertEquals(expectedPassword, adminRequestDTO.getPassword());
+    }
+
+    @Test
+    void testAdminRequestDTOSetters() {
+        AdminRequestDTO adminRequestDTO = new AdminRequestDTO();
+
+        adminRequestDTO.setName("New Admin");
+        adminRequestDTO.setEmail("newadmin@example.com");
+        adminRequestDTO.setPassword("newpassword");
+
+        assertEquals("New Admin", adminRequestDTO.getName());
+        assertEquals("newadmin@example.com", adminRequestDTO.getEmail());
+        assertEquals("newpassword", adminRequestDTO.getPassword());
+    }
+}

--- a/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/TaskDTOTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/TaskDTOTest.java
@@ -18,7 +18,7 @@ public class TaskDTOTest {
         assertEquals(1, dto.getTaskId());
         assertEquals("Task Title", dto.getTitle());
         assertEquals("Task Description", dto.getDescription());
-        assertFalse(dto.isLocked());
+        assertFalse(dto.getIsLocked());
         assertEquals("Open", dto.getStatus());
         assertEquals(dueDate, dto.getDueDate());
         assertEquals(201, dto.getTeamId());
@@ -40,7 +40,7 @@ public class TaskDTOTest {
         assertEquals(2, dto.getTaskId());
         assertEquals("Updated Task Title", dto.getTitle());
         assertEquals("Updated Description", dto.getDescription());
-        assertTrue(dto.isLocked());
+        assertTrue(dto.getIsLocked());
         assertEquals("In Progress", dto.getStatus());
         assertEquals(newDueDate, dto.getDueDate());
         assertEquals(202, dto.getTeamId());

--- a/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/TeamRequestDTOTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/TeamRequestDTOTest.java
@@ -1,0 +1,22 @@
+package com.example.task_manager.DTO_tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.task_manager.DTO.TeamRequestDTO;
+
+public class TeamRequestDTOTest {
+    @Test
+    void testSettersAndGetters() {
+        TeamRequestDTO teamRequestDTO = new TeamRequestDTO();
+
+        teamRequestDTO.setTeamId(2);
+        teamRequestDTO.setTeamName("Marketing Team");
+        teamRequestDTO.setTeamLeadId(200);
+
+        assertEquals(2, teamRequestDTO.getTeamId());
+        assertEquals("Marketing Team", teamRequestDTO.getTeamName());
+        assertEquals(200, teamRequestDTO.getTeamLeadId());
+    }
+}

--- a/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/UpdateEmailRequestDTOTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/UpdateEmailRequestDTOTest.java
@@ -1,0 +1,27 @@
+package com.example.task_manager.DTO_tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.task_manager.DTO.UpdateEmailRequestDTO;
+
+public class UpdateEmailRequestDTOTest {
+    @Test
+    void testUpdateNameRequestDTOConstructorAndGetters() {
+        String expectedNewEmail = "email@example.com";
+
+        UpdateEmailRequestDTO updateEmailRequestDTO = new UpdateEmailRequestDTO(expectedNewEmail);
+
+        assertEquals(expectedNewEmail, updateEmailRequestDTO.getNewEmail());
+    }
+
+    @Test
+    void testUpdateNameRequestDTOSetters() {
+        UpdateEmailRequestDTO updateEmailRequestDTO = new UpdateEmailRequestDTO();
+
+        updateEmailRequestDTO.setNewEmail("new_email@example.com");
+
+        assertEquals("new_email@example.com", updateEmailRequestDTO.getNewEmail());
+    }
+}

--- a/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/UpdateNameRequestDTOTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/DTO_tests/UpdateNameRequestDTOTest.java
@@ -1,0 +1,27 @@
+package com.example.task_manager.DTO_tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.task_manager.DTO.UpdateNameRequestDTO;
+
+public class UpdateNameRequestDTOTest {
+    @Test
+    void testUpdateNameRequestDTOConstructorAndGetters() {
+        String expectedNewName = "Updated Admin Name";
+
+        UpdateNameRequestDTO updateNameRequestDTO = new UpdateNameRequestDTO(expectedNewName);
+
+        assertEquals(expectedNewName, updateNameRequestDTO.getNewName());
+    }
+
+    @Test
+    void testUpdateNameRequestDTOSetters() {
+        UpdateNameRequestDTO updateNameRequestDTO = new UpdateNameRequestDTO();
+
+        updateNameRequestDTO.setNewName("New Admin Name");
+
+        assertEquals("New Admin Name", updateNameRequestDTO.getNewName());
+    }
+}

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/AdminControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/AdminControllerTest.java
@@ -3,10 +3,13 @@ package com.example.task_manager.controller_tests;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
 import com.example.task_manager.DTO.AdminDTO;
+import com.example.task_manager.DTO.AdminRequestDTO;
 import com.example.task_manager.DTO.TeamMemberDTO;
 import com.example.task_manager.controller.AdminController;
 import com.example.task_manager.service.AdminService;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -15,6 +18,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.task_manager.DTO.UpdateEmailRequestDTO;
+import com.example.task_manager.DTO.UpdateNameRequestDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(AdminController.class)
 public class AdminControllerTest {
@@ -27,6 +34,9 @@ public class AdminControllerTest {
 
     @InjectMocks
     private AdminController adminController;
+
+    @Autowired
+    private ObjectMapper objectMapper; //used top convert DTO's to json
 
     private AdminDTO mockAdmin;
     private TeamMemberDTO mockMember;
@@ -44,15 +54,17 @@ public class AdminControllerTest {
     // Create an Admin
     @Test
     void testCreateAdmin() throws Exception {
+        AdminRequestDTO requestDTO = new AdminRequestDTO("Admin User", "admin@example.com", mockAdminPassword);
+
         when(adminService.createAdmin("Admin User", "admin@example.com",mockAdminPassword)).thenReturn(mockAdmin);
 
         mockMvc.perform(post("/api/admin")
-                .param("name", "Admin User")
-                .param("email", "admin@example.com")
-                .param("userPassword","mock_password_admin"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accountId").value(1))
-                .andExpect(jsonPath("$.userName").value("Admin User"));
+                .andExpect(jsonPath("$.userName").value("Admin User"))
+                .andExpect(jsonPath("$.userEmail").value("admin@example.com"));
     }
 
     // Delete Admin
@@ -67,10 +79,13 @@ public class AdminControllerTest {
     // Modify Admin Name
     @Test
     void testModifyAdminName() throws Exception {
+        UpdateNameRequestDTO requestDTO = new UpdateNameRequestDTO("New Admin Name");
+
         when(adminService.modifyAdminName(1, "New Admin Name")).thenReturn(new AdminDTO(1, "New Admin Name", "admin@example.com"));
 
         mockMvc.perform(put("/api/admin/1/update-name")
-                .param("newName", "New Admin Name"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userName").value("New Admin Name"));
     }
@@ -78,68 +93,79 @@ public class AdminControllerTest {
     // Modify Admin Email
     @Test
     void testModifyAdminEmail() throws Exception {
-        when(adminService.modifyAdminEmail(1, "newadmin@example.com"))
-                .thenReturn(new AdminDTO(1, "Admin User", "newadmin@example.com"));
+        UpdateEmailRequestDTO requestDTO = new UpdateEmailRequestDTO("new_email@example.com");
+
+        when(adminService.modifyAdminEmail(1, "new_email@example.com"))
+                .thenReturn(new AdminDTO(1, "Admin User", "new_email@example.com"));
 
         mockMvc.perform(put("/api/admin/1/update-email")
-                .param("newEmail", "newadmin@example.com"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userEmail").value("newadmin@example.com"));
+                .andExpect(jsonPath("$.userEmail").value("new_email@example.com"));
     }
 
     // Create Team Member
     @Test
     void testCreateTeamMember() throws Exception {
-        when(adminService.createTeamMember("John Doe", "john.doe@example.com",mockTMPassword)).thenReturn(mockMember);
+        AdminRequestDTO requestDTO = new AdminRequestDTO("John Doe", "john.doe@example.com", mockTMPassword);
+
+        when(adminService.createTeamMember("John Doe", "john.doe@example.com", mockTMPassword)).thenReturn(mockMember);
 
         mockMvc.perform(post("/api/admin/team-member")
-                .param("name", "John Doe")
-                .param("email", "john.doe@example.com")
-                .param("userPassword","mock_password_TM"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accountId").value(2))
-                .andExpect(jsonPath("$.userName").value("John Doe"));
+                .andExpect(jsonPath("$.userName").value("John Doe"))
+                .andExpect(jsonPath("$.userEmail").value("john.doe@example.com"));
     }
 
     // Modify Team Member Name 
     @Test
     void testModifyTeamMemberName() throws Exception {
-        when(adminService.modifyTeamMemberName(1, "Jane Doe"))
-                .thenReturn(new TeamMemberDTO(1, "Jane Doe", "john.doe@example.com"));
+        UpdateNameRequestDTO requestDTO = new UpdateNameRequestDTO("TeamMember User");
+
+        when(adminService.modifyTeamMemberName(1, "TeamMember User"))
+                .thenReturn(new TeamMemberDTO(1, "TeamMember User", "TM@example.com"));
 
         mockMvc.perform(put("/api/admin/team-member/1/update-name")
-                .param("newName", "Jane Doe")
-                .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userName").value("Jane Doe"));
+                .andExpect(jsonPath("$.userName").value("TeamMember User"));
     }
 
     // Modify Team Member Email 
     @Test
     void testModifyTeamMemberEmail() throws Exception {
-        when(adminService.modifyTeamMemberEmail(1, "jane.doe@example.com"))
-                .thenReturn(new TeamMemberDTO(1, "John Doe", "jane.doe@example.com"));
+        UpdateEmailRequestDTO requestDTO = new UpdateEmailRequestDTO("new_email@example.com");
+
+        when(adminService.modifyTeamMemberEmail(1, "new_email@example.com"))
+                .thenReturn(new TeamMemberDTO(1, "John Doe", "new_email@example.com"));
 
         mockMvc.perform(put("/api/admin/team-member/1/update-email")
-                .param("newEmail", "jane.doe@example.com")
-                .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userEmail").value("jane.doe@example.com"));
+                .andExpect(jsonPath("$.userEmail").value("new_email@example.com"));
     }
 
     // Modify Team Member Email (Invalid Format) 
     @Test
     void testModifyTeamMemberEmailInvalidFormat() throws Exception {
+        UpdateEmailRequestDTO requestDTO = new UpdateEmailRequestDTO("invalid-email");
+
         when(adminService.modifyTeamMemberEmail(1, "invalid-email"))
                 .thenThrow(new RuntimeException("Invalid email format"));
 
         mockMvc.perform(put("/api/admin/team-member/1/update-email")
-                .param("newEmail", "invalid-email")
-                .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("Invalid email format"));
     }
-
+    
     // Delete Team Member 
     @Test
     void testDeleteTeamMember() throws Exception {

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TeamEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TeamEntityTest.java
@@ -62,7 +62,7 @@ public class TeamEntityTest {
         entMan.flush();
 
         TeamMember member_1 = new TeamMember("John Doe", "john@example.com","defaultpw");
-        TeamMember member_2 = new TeamMember("Alice Wonder", "alice@example.com","defaultpw");
+        TeamMember member_2 = new TeamMember("Alice Chains", "alice_chains@example.com","defaultpw");
         entMan.persist(member_1);
         entMan.persist(member_2);
         entMan.flush();

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AdminServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AdminServiceTest.java
@@ -2,6 +2,7 @@ package com.example.task_manager.service_tests;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import jakarta.transaction.Transactional;
 
 import com.example.task_manager.DTO.AdminDTO;
 import com.example.task_manager.DTO.TaskDTO;
+import com.example.task_manager.DTO.TaskRequestDTO;
 import com.example.task_manager.DTO.TeamDTO;
 import com.example.task_manager.DTO.TeamMemberDTO;
 import com.example.task_manager.entity.Admin;
@@ -85,8 +87,29 @@ public class AdminServiceTest {
 		team.setTeamName("Team Name " + System.nanoTime());
 		team = teamRepository.save(team);
 
-		unlockedTask = adminService.createTask("Unlocked Task", null, false, "Open", null, null, team, null);
-		lockedTask = adminService.createTask("Locked Task", null, false, "Open", null, null, team, null);
+		TaskRequestDTO taskRequest = new TaskRequestDTO(
+			"Unlocked Task",
+			"Task Description",
+			false,
+			"Open",
+			LocalDate.now(),
+			null,
+			team.getTeamId()
+		);
+
+		unlockedTask = adminService.createTask(taskRequest);
+
+		taskRequest = new TaskRequestDTO(
+			"Locked Task",
+			"Task Description",
+			true,
+			"Open",
+			LocalDate.now(),
+			null,
+			team.getTeamId()
+		);
+
+		lockedTask = adminService.createTask(taskRequest);
 	}
 
 	// Try to create admin account

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AdminServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AdminServiceTest.java
@@ -72,13 +72,13 @@ public class AdminServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		isAssignedRepository.deleteAllInBatch();
-		isMemberOfRepository.deleteAllInBatch();
-		taskRepository.deleteAllInBatch();
-		teamRepository.deleteAllInBatch();
-		authInfoRepository.deleteAllInBatch();
-		teamMemberRepository.deleteAllInBatch();
-		adminRepository.deleteAllInBatch();
+		isAssignedRepository.deleteAll();
+		isMemberOfRepository.deleteAll();
+		taskRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		authInfoRepository.deleteAll();
+		adminRepository.deleteAll();
+		teamRepository.deleteAll();
 
 		admin = adminService.createAdmin("Admin Name", "admin" + System.nanoTime() + "@example.com","defaultpw");
 		teamMember = adminService.createTeamMember("TM Name", "teamMember" + System.nanoTime() + "@example.com","defaultpw");

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AuthInfoServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AuthInfoServiceTest.java
@@ -52,12 +52,6 @@ public class AuthInfoServiceTest {
 	@Autowired
 	private AuthInfoRepository authInfoRepository;
 
-    @Autowired
-    private IsMemberOfRepository isMemberOfRepository;
-        
-    @Autowired
-    private AuthInfoRepository authInfoRepository;
-
     private TeamMember teamMember;
     private Admin admin;
 

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AuthInfoServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AuthInfoServiceTest.java
@@ -10,10 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import jakarta.transaction.Transactional;
 
 import com.example.task_manager.entity.TeamMember;
+import com.example.task_manager.repository.AdminRepository;
 import com.example.task_manager.repository.AuthInfoRepository;
 import com.example.task_manager.repository.IsAssignedRepository;
 import com.example.task_manager.repository.IsMemberOfRepository;
+import com.example.task_manager.repository.TaskRepository;
 import com.example.task_manager.repository.TeamMemberRepository;
+import com.example.task_manager.repository.TeamRepository;
 import com.example.task_manager.service.AuthInfoService;
 
 @SpringBootTest
@@ -21,19 +24,28 @@ import com.example.task_manager.service.AuthInfoService;
 @Transactional
 public class AuthInfoServiceTest {
 
-@Autowired
+    @Autowired
     private AuthInfoService authInfoService;
 
-@Autowired
+    @Autowired
+	private AdminRepository adminRepository;
+
+	@Autowired
 	private TeamMemberRepository teamMemberRepository;
 
-@Autowired
+	@Autowired
+	private TaskRepository taskRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
 	private IsAssignedRepository isAssignedRepository;
 
-@Autowired
+	@Autowired
 	private IsMemberOfRepository isMemberOfRepository;
 	
-@Autowired
+	@Autowired
 	private AuthInfoRepository authInfoRepository;
 
 
@@ -42,10 +54,13 @@ private TeamMember teamMember;
 
 @BeforeEach
 	void setUp() {
-        isAssignedRepository.deleteAllInBatch();
-        isMemberOfRepository.deleteAllInBatch();
-        authInfoRepository.deleteAllInBatch();
-		teamMemberRepository.deleteAllInBatch();
+        isAssignedRepository.deleteAll();
+		isMemberOfRepository.deleteAll();
+		taskRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		authInfoRepository.deleteAll();
+		adminRepository.deleteAll();
+		teamRepository.deleteAll();
 
         teamMember = new TeamMember("Authentication Tester", "auth_test" + System.nanoTime() + "@secure.com","defaultpw");
 		teamMember = teamMemberRepository.save(teamMember);

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsAssignedServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsAssignedServiceTest.java
@@ -15,7 +15,10 @@ import com.example.task_manager.DTO.IsAssignedDTO;
 import com.example.task_manager.entity.Task;
 import com.example.task_manager.entity.Team;
 import com.example.task_manager.entity.TeamMember;
+import com.example.task_manager.repository.AdminRepository;
 import com.example.task_manager.repository.AuthInfoRepository;
+import com.example.task_manager.repository.IsAssignedRepository;
+import com.example.task_manager.repository.IsMemberOfRepository;
 import com.example.task_manager.repository.TaskRepository;
 import com.example.task_manager.repository.TeamMemberRepository;
 import com.example.task_manager.repository.TeamRepository;
@@ -30,16 +33,25 @@ public class IsAssignedServiceTest {
 	private IsAssignedService isAssignedService;
 
 	@Autowired
-	private TaskRepository taskRepository;
-	
+	private AdminRepository adminRepository;
+
 	@Autowired
 	private TeamMemberRepository teamMemberRepository;
+
+	@Autowired
+	private TaskRepository taskRepository;
 
 	@Autowired
 	private TeamRepository teamRepository;
 
 	@Autowired
-    private AuthInfoRepository authInfoRepository;
+	private IsAssignedRepository isAssignedRepository;
+
+	@Autowired
+	private IsMemberOfRepository isMemberOfRepository;
+	
+	@Autowired
+	private AuthInfoRepository authInfoRepository;
 
 	private Task task;
 	private TeamMember teamMember;
@@ -47,10 +59,13 @@ public class IsAssignedServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		taskRepository.deleteAllInBatch();
-		teamRepository.deleteAllInBatch();
-		authInfoRepository.deleteAllInBatch();
-		teamMemberRepository.deleteAllInBatch();
+		isAssignedRepository.deleteAll();
+		isMemberOfRepository.deleteAll();
+		taskRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		authInfoRepository.deleteAll();
+		adminRepository.deleteAll();
+		teamRepository.deleteAll();
 
 		teamMember = new TeamMember("Team Member", "teamMember" + System.nanoTime() + "@example.com","defaultpw");
 		teamMember = teamMemberRepository.save(teamMember);

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsMemberOfServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsMemberOfServiceTest.java
@@ -11,7 +11,10 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import com.example.task_manager.DTO.TeamDTO;
 import com.example.task_manager.DTO.TeamMemberDTO;
+import com.example.task_manager.repository.AdminRepository;
 import com.example.task_manager.repository.AuthInfoRepository;
+import com.example.task_manager.repository.IsAssignedRepository;
+import com.example.task_manager.repository.IsMemberOfRepository;
 import com.example.task_manager.repository.TaskRepository;
 import com.example.task_manager.repository.TeamMemberRepository;
 import com.example.task_manager.repository.TeamRepository;
@@ -37,16 +40,25 @@ public class IsMemberOfServiceTest {
     private IsMemberOfService isMemberOfService;
 
     @Autowired
-    private TeamRepository teamRepository;
+	private AdminRepository adminRepository;
 
-    @Autowired
-    private TaskRepository taskRepository;
+	@Autowired
+	private TeamMemberRepository teamMemberRepository;
 
-    @Autowired
-    private TeamMemberRepository teamMemberRepository;
-    
-    @Autowired
-    private AuthInfoRepository authInfoRepository;
+	@Autowired
+	private TaskRepository taskRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private IsAssignedRepository isAssignedRepository;
+
+	@Autowired
+	private IsMemberOfRepository isMemberOfRepository;
+	
+	@Autowired
+	private AuthInfoRepository authInfoRepository;
 
     private TeamDTO team;
     private TeamMemberDTO teamLead;
@@ -55,10 +67,13 @@ public class IsMemberOfServiceTest {
     @BeforeEach
     void setUp() {
         // Clear DB to avoid conflicts
-        taskRepository.deleteAllInBatch();
-        teamRepository.deleteAllInBatch();
-        authInfoRepository.deleteAllInBatch();
-        teamMemberRepository.deleteAllInBatch();
+        isAssignedRepository.deleteAll();
+		isMemberOfRepository.deleteAll();
+		taskRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		authInfoRepository.deleteAll();
+		adminRepository.deleteAll();
+		teamRepository.deleteAll();
 
         teamLead = adminService.createTeamMember("Team Lead", "team_lead" + System.nanoTime() + "@example.com","defaultpw");
         team = teamService.createTeam("Development Team " + System.nanoTime(), teamLead.getAccountId());

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamMemberServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamMemberServiceTest.java
@@ -21,8 +21,10 @@ import com.example.task_manager.entity.TeamMember;
 import com.example.task_manager.repository.TaskRepository;
 import com.example.task_manager.repository.TeamMemberRepository;
 import com.example.task_manager.repository.TeamRepository;
+import com.example.task_manager.repository.AdminRepository;
 import com.example.task_manager.repository.AuthInfoRepository;
 import com.example.task_manager.repository.IsAssignedRepository;
+import com.example.task_manager.repository.IsMemberOfRepository;
 import com.example.task_manager.service.AuthInfoService;
 import com.example.task_manager.service.TeamMemberService;
 
@@ -38,10 +40,13 @@ public class TeamMemberServiceTest {
 	private TeamMemberService teamMemberService;
 
 	@Autowired
-	private TaskRepository taskRepository;
+	private AdminRepository adminRepository;
 
 	@Autowired
 	private TeamMemberRepository teamMemberRepository;
+
+	@Autowired
+	private TaskRepository taskRepository;
 
 	@Autowired
 	private TeamRepository teamRepository;
@@ -50,7 +55,10 @@ public class TeamMemberServiceTest {
 	private IsAssignedRepository isAssignedRepository;
 
 	@Autowired
-    private AuthInfoRepository authInfoRepository;
+	private IsMemberOfRepository isMemberOfRepository;
+	
+	@Autowired
+	private AuthInfoRepository authInfoRepository;
 
 	private Task task;
 	private TeamMember teamMember;
@@ -58,11 +66,13 @@ public class TeamMemberServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		isAssignedRepository.deleteAllInBatch();
-		taskRepository.deleteAllInBatch();
-		teamRepository.deleteAllInBatch();
-		authInfoRepository.deleteAllInBatch();
-		teamMemberRepository.deleteAllInBatch();
+		isAssignedRepository.deleteAll();
+		isMemberOfRepository.deleteAll();
+		taskRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		authInfoRepository.deleteAll();
+		adminRepository.deleteAll();
+		teamRepository.deleteAll();
 
 		teamMember = new TeamMember("Team Member", "teamMember" + System.nanoTime() + "@example.com","defaultpw");
 		teamMember = teamMemberRepository.save(teamMember);

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamMemberServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamMemberServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import jakarta.transaction.Transactional;
 
 import com.example.task_manager.DTO.TaskDTO;
+import com.example.task_manager.DTO.TaskRequestDTO;
 import com.example.task_manager.DTO.TeamMemberDTO;
 import com.example.task_manager.entity.Task;
 import com.example.task_manager.entity.Team;
@@ -75,7 +76,17 @@ public class TeamMemberServiceTest {
 
 	@Test
 	void testCreateTask() {
-		TaskDTO newTaskDTO = teamMemberService.createTask("New Task", "Task Description", false, "Open", LocalDate.now().plusDays(3), LocalDate.now().plusDays(5), team, null);
+		TaskRequestDTO taskRequestDTO = new TaskRequestDTO(
+			"New Task",
+			"Task Description",
+			false,
+			"Open",
+			LocalDate.now().plusDays(5),
+			null,
+			team.getTeamId()
+		);
+
+		TaskDTO newTaskDTO = teamMemberService.createTask(taskRequestDTO);
 
 		assertNotNull(newTaskDTO);
 		assertEquals("New Task", newTaskDTO.getTitle());
@@ -85,27 +96,28 @@ public class TeamMemberServiceTest {
 
 	@Test
 	void testCreateTaskWithNullTitle() {
-		Exception exception = assertThrows(RuntimeException.class, 
-			() -> teamMemberService.createTask(null, "Task Description", false, "Open", 
-				LocalDate.now().plusDays(3), LocalDate.now().plusDays(5), team, null));
+		TaskRequestDTO taskRequestDTO = new TaskRequestDTO(
+				null, "Task Description", false, "Open", LocalDate.now(), null, team.getTeamId());
 
-		assertTrue(exception.getMessage().contains("Task title cannot be null"));
+		Exception exception = assertThrows(RuntimeException.class, () -> teamMemberService.createTask(taskRequestDTO));
+
+		assertTrue(exception.getMessage().contains("Task title cannot be null or empty"));
 	}
 
 	@Test
 	void testCreateTaskWithEmptyTitle() {
-		Exception exception = assertThrows(RuntimeException.class, 
-			() -> teamMemberService.createTask("", "Task Description", false, "Open", 
-				LocalDate.now().plusDays(3), LocalDate.now().plusDays(5), team, null));
+		TaskRequestDTO taskRequestDTO = new TaskRequestDTO("", "Task Description", false, "Open", LocalDate.now(), null, team.getTeamId());
+
+        Exception exception = assertThrows(RuntimeException.class, () -> teamMemberService.createTask(taskRequestDTO));
 
 		assertTrue(exception.getMessage().contains("Task title cannot be null or empty"));
 	}
 
 	@Test
 	void testCreateTaskWithNullTeam() {
-		Exception exception = assertThrows(RuntimeException.class, 
-			() -> teamMemberService.createTask("New Task", "Task Description", false, "Open", 
-				LocalDate.now().plusDays(3), LocalDate.now().plusDays(5), null, null));
+		TaskRequestDTO taskRequestDTO = new TaskRequestDTO("New Task", "Task Description", false, "Open", LocalDate.now(), null, null);
+
+        Exception exception = assertThrows(RuntimeException.class, () -> teamMemberService.createTask(taskRequestDTO));
 
 		assertTrue(exception.getMessage().contains("Task must be assigned to a team"));
 	}
@@ -128,19 +140,37 @@ public class TeamMemberServiceTest {
 
 	@Test
 	void testEditTask() {
-		TaskDTO updatedTask = teamMemberService.editTask(task.getTaskId(), "Updated Task Title", "Updated Description", true, "In Progress", LocalDate.now().plusDays(7), LocalDate.now().plusDays(10));
+		TaskDTO taskDTO = new TaskDTO(
+			task.getTaskId(),
+			"Updated Task Title",
+			"Updated Description",
+			true,
+			"In Progress",
+			LocalDate.now(),
+			team.getTeamId()
+		);
+
+		TaskDTO updatedTask = teamMemberService.editTask(task.getTaskId(), taskDTO);
 
 		assertEquals("Updated Task Title", updatedTask.getTitle());
 		assertEquals("Updated Description", updatedTask.getDescription());
 		assertEquals("In Progress", updatedTask.getStatus());
-		assertTrue(updatedTask.isLocked());
+		assertTrue(updatedTask.getIsLocked());
 	}
 
 	@Test
 	void testEditNonExistentTask() {
-		Exception exception = assertThrows(RuntimeException.class, 
-			() -> teamMemberService.editTask(9999, "Updated Title", "Updated Description", true, 
-				"In Progress", LocalDate.now().plusDays(7), LocalDate.now().plusDays(10)));
+		TaskDTO taskDTO = new TaskDTO(
+			9999,
+			"Updated Title",
+			"Updated Description",
+			true,
+			"In Progress",
+			LocalDate.now(),
+			team.getTeamId()
+		);
+
+		Exception exception = assertThrows(RuntimeException.class, () -> teamMemberService.editTask(9999, taskDTO));
 
 		assertTrue(exception.getMessage().contains("Task not found"));
 	}

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamServiceTest.java
@@ -114,20 +114,32 @@ public class TeamServiceTest {
 	}
 
 	@Test
-	void testChangeTeamLead() {
-		teamService.changeTeamLead(team.getTeamId(), newTeamLead.getAccountId());
+    void testChangeTeamLead() {
+        int teamId = team.getTeamId();
+        String newTeamName = "Updated Team Name";
+        int newTeamLeadId = newTeamLead.getAccountId();
 
-		Team updatedTeam = teamRepository.findById(team.getTeamId()).orElseThrow();
-		assertEquals(newTeamLead.getAccountId(), updatedTeam.getTeamLead().getAccountId());
-	}
+        TeamDTO updatedTeamDTO = teamService.changeTeamLead(teamId, newTeamName, newTeamLeadId);
+
+        assertNotNull(updatedTeamDTO);
+        assertEquals(newTeamName, updatedTeamDTO.getTeamName());
+        assertEquals(newTeamLeadId, updatedTeamDTO.getTeamLeadId());
+
+        Team updatedTeam = teamRepository.findById(teamId).orElseThrow();
+        assertEquals(newTeamName, updatedTeam.getTeamName());
+        assertEquals(newTeamLeadId, updatedTeam.getTeamLead().getAccountId());
+    }
 
 	@Test
-	void testChangeTeamLeadToNonExistentMember() {
-		Exception exception = assertThrows(RuntimeException.class, 
-			() -> teamService.changeTeamLead(team.getTeamId(), 9999));
+    void testChangeTeamLeadToNonExistentMember() {
+        int teamId = team.getTeamId();
+        String newTeamName = "Updated Team Name";
 
-		assertTrue(exception.getMessage().contains("Team Lead not found"));
-	}
+        Exception exception = assertThrows(RuntimeException.class, 
+            () -> teamService.changeTeamLead(teamId, newTeamName, 9999));
+
+        assertTrue(exception.getMessage().contains("Team Lead not found"));
+    }
 
 	@Test
 	void testGetTeamMembers() {

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamServiceTest.java
@@ -19,8 +19,11 @@ import com.example.task_manager.entity.Team;
 import com.example.task_manager.entity.TeamMember;
 import com.example.task_manager.repository.TeamMemberRepository;
 import com.example.task_manager.repository.TeamRepository;
+import com.example.task_manager.repository.AdminRepository;
 import com.example.task_manager.repository.AuthInfoRepository;
+import com.example.task_manager.repository.IsAssignedRepository;
 import com.example.task_manager.repository.IsMemberOfRepository;
+import com.example.task_manager.repository.TaskRepository;
 import com.example.task_manager.service.IsMemberOfService;
 import com.example.task_manager.service.TeamService;
 
@@ -36,16 +39,25 @@ public class TeamServiceTest {
 	private IsMemberOfService isMemberOfService;
 
 	@Autowired
-	private TeamRepository teamRepository;
+	private AdminRepository adminRepository;
 
 	@Autowired
 	private TeamMemberRepository teamMemberRepository;
 
 	@Autowired
-	private IsMemberOfRepository isMemberOfRepository;
+	private TaskRepository taskRepository;
 
 	@Autowired
-    private AuthInfoRepository authInfoRepository;
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private IsAssignedRepository isAssignedRepository;
+
+	@Autowired
+	private IsMemberOfRepository isMemberOfRepository;
+	
+	@Autowired
+	private AuthInfoRepository authInfoRepository;
 
 	private TeamDTO team;
 	private TeamMember teamLead;
@@ -54,10 +66,13 @@ public class TeamServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		isMemberOfRepository.deleteAllInBatch();
-		teamRepository.deleteAllInBatch();
-		authInfoRepository.deleteAllInBatch();
-		teamMemberRepository.deleteAllInBatch();
+		isAssignedRepository.deleteAll();
+		isMemberOfRepository.deleteAll();
+		taskRepository.deleteAll();
+		teamMemberRepository.deleteAll();
+		authInfoRepository.deleteAll();
+		adminRepository.deleteAll();
+		teamRepository.deleteAll();
 
 		teamLead = new TeamMember("Team Lead", "team_lead" + System.nanoTime() + "@example.com","defaultpw");
 		teamLead = teamMemberRepository.save(teamLead);

--- a/backend/task-manager/src/test/resources/application-test.properties
+++ b/backend/task-manager/src/test/resources/application-test.properties
@@ -9,3 +9,4 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+spring.test.execution.parallel.enabled=false

--- a/frontend/react-app/src/api/teamApi.js
+++ b/frontend/react-app/src/api/teamApi.js
@@ -43,12 +43,12 @@ export const deleteTeam = async (teamId) => {
 };
 
 //Change team lead
-export const changeTeamLead = async (teamId, teamLeadId) => {
+export const changeTeamLead = async (teamId, teamLeadId, teamName) => {
     try {
         const response = await fetch(`${BASE_URL}/${teamId}/change-lead`, {
             method: 'PUT',
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({teamLeadId})
+            body: JSON.stringify({teamLeadId, teamName})
         });
 
         if (!response.ok) {

--- a/frontend/react-app/src/tests/api-tests/teamApiTest.test.js
+++ b/frontend/react-app/src/tests/api-tests/teamApiTest.test.js
@@ -46,18 +46,20 @@ describe('Team API', () => {
     test('changeTeamLead should return new team data on success', async () => {
         const updatedTeam = {
             teamId: 1,
-            teamLeadId: 1
+            teamLeadId: 1,
+            teamName: "New Team Name"
         };
 
         fetch.mockResponseOnce(JSON.stringify(updatedTeam), { status: 200 });
 
-        const result = await changeTeamLead(1, 1);
+        const result = await changeTeamLead(1, 1, "New Team Name");
 
         expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/1/change-lead`, {
             method: 'PUT',
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-                teamLeadId: 1
+                teamLeadId: 1,
+                teamName: "New Team Name"
             })
         });
 


### PR DESCRIPTION
Some of the backend API and frontend API code was mismatched, so the frontend used request bodies but the backend used request parameters. Changed the backend so it used request parameters, which is better overall. Adjusted tests as necessary.

The Service tests int he backend kept giving deadlock errors, so changed all deleteAllInBatch() calls in the setUp methods to just deleteAll().

Adjusted API documentation as the backend was changed. All tests are running and passing.

Resolves #102 