### PR TITLE
removed team name and description

### DIFF
--- a/frontend/react-app/src/pages/TeamTasks.jsx
+++ b/frontend/react-app/src/pages/TeamTasks.jsx
@@ -146,8 +146,7 @@ function TeamTasks(){
             dataToUse={setUpDataComplete(fakeData)}
             headersAndAccessors={headerAndAccessorsComplete}
             />
-            <h2>Team 1 Name</h2>
-            <p>Description of what the team is working on. idk?</p>
+            
 
             <h2>Team Members</h2>
             <div className="team-list">


### PR DESCRIPTION
removed unnecessary team name and description from team tasks page, we don't have the creation of this in our functional requirements 