### PR TITLE
Testing classes configuration

### DIFF
--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/AdminControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/AdminControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.task_manager.DTO.UpdateEmailRequestDTO;
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class AdminControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/AuthInfoControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/AuthInfoControllerTest.java
@@ -14,9 +14,11 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(AuthController.class)
+@ActiveProfiles("test")
 public class AuthInfoControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/IsAssignedControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/IsAssignedControllerTest.java
@@ -12,9 +12,11 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(IsAssignedController.class)
+@ActiveProfiles("test")
 public class IsAssignedControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/IsMemberOfControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/IsMemberOfControllerTest.java
@@ -13,9 +13,11 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(IsMemberOfController.class)
+@ActiveProfiles("test")
 public class IsMemberOfControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/NotificationControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/NotificationControllerTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @WebMvcTest(NotificationController.class)
+@ActiveProfiles("test")
 public class NotificationControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/TaskControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/TaskControllerTest.java
@@ -3,9 +3,11 @@ package com.example.task_manager.controller_tests;
 import com.example.task_manager.controller.TaskController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(TaskController.class)
+@ActiveProfiles("test")
 public class TaskControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/TeamControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/TeamControllerTest.java
@@ -20,12 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
 import java.util.List;
 
 @WebMvcTest(TeamController.class)
+@ActiveProfiles("test")
 public class TeamControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/TeamMemberControllerTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/controller_tests/TeamMemberControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -27,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @WebMvcTest(TeamMemberController.class)
+@ActiveProfiles("test")
 public class TeamMemberControllerTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/AdminEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/AdminEntityTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.Admin;
 import com.example.task_manager.entity.TeamMember;
@@ -19,6 +20,7 @@ import jakarta.transaction.Transactional;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class AdminEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/AuthInfoEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/AuthInfoEntityTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.AuthInfo;
 import com.example.task_manager.entity.TeamMember;
@@ -17,6 +18,7 @@ import jakarta.transaction.Transactional;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class AuthInfoEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/IsAssignedEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/IsAssignedEntityTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.IsAssigned;
 import com.example.task_manager.entity.Task;
@@ -18,6 +19,7 @@ import com.example.task_manager.entity.TeamMember;
 @DataJpaTest
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class IsAssignedEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/IsMemberOfEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/IsMemberOfEntityTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.IsMemberOf;
 import com.example.task_manager.entity.Team;
@@ -14,6 +15,7 @@ import com.example.task_manager.entity.TeamMember;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class IsMemberOfEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/NotificationEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/NotificationEntityTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.Notification;
 import com.example.task_manager.entity.Task;
@@ -21,6 +22,7 @@ import jakarta.persistence.PersistenceException;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class NotificationEntityTest {
     
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TaskEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TaskEntityTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.IsAssigned;
 import com.example.task_manager.entity.Task;
@@ -17,6 +18,7 @@ import com.example.task_manager.entity.TeamMember;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TaskEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TeamEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TeamEntityTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.IsAssigned;
 import com.example.task_manager.entity.Task;
@@ -18,6 +19,7 @@ import com.example.task_manager.entity.IsMemberOf;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TeamEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TeamMemberEntityTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/entity_tests/TeamMemberEntityTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.AuthInfo;
 import com.example.task_manager.entity.IsAssigned;
@@ -20,6 +21,7 @@ import jakarta.persistence.PersistenceException;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TeamMemberEntityTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/AdminRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/AdminRepositoryTest.java
@@ -2,9 +2,11 @@ package com.example.task_manager.repository_tests;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class AdminRepositoryTest {
     
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/AuthInfoRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/AuthInfoRepositoryTest.java
@@ -2,9 +2,11 @@ package com.example.task_manager.repository_tests;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class AuthInfoRepositoryTest {
 
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/IsAssignedRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/IsAssignedRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.IsAssigned;
 import com.example.task_manager.entity.Task;
@@ -24,6 +25,7 @@ import com.example.task_manager.repository.AuthInfoRepository;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class IsAssignedRepositoryTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/IsMemberOfRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/IsMemberOfRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.IsMemberOf;
 import com.example.task_manager.entity.Team;
@@ -23,6 +24,7 @@ import com.example.task_manager.repository.AdminRepository;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class IsMemberOfRepositoryTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/NotificationRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/NotificationRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.entity.Notification;
 import com.example.task_manager.entity.Task;
@@ -23,6 +24,7 @@ import com.example.task_manager.repository.TeamRepository;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class NotificationRepositoryTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/TaskRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/TaskRepositoryTest.java
@@ -2,9 +2,11 @@ package com.example.task_manager.repository_tests;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TaskRepositoryTest {
 
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/TeamMemberRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/TeamMemberRepositoryTest.java
@@ -2,9 +2,11 @@ package com.example.task_manager.repository_tests;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TeamMemberRepositoryTest {
 
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/TeamRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/TeamRepositoryTest.java
@@ -2,9 +2,11 @@ package com.example.task_manager.repository_tests;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TeamRepositoryTest {
 
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AdminServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AdminServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
 import jakarta.transaction.Transactional;
 
@@ -29,6 +30,7 @@ import com.example.task_manager.service.TeamService;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class AdminServiceTest {
 

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AuthInfoServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/AuthInfoServiceTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
 import jakarta.transaction.Transactional;
 
 import com.example.task_manager.DTO.AuthInfoDTO;
@@ -21,6 +23,7 @@ import com.example.task_manager.service.AuthInfoService;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class AuthInfoServiceTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsAssignedServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsAssignedServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
 import jakarta.transaction.Transactional;
 
 import com.example.task_manager.DTO.IsAssignedDTO;
@@ -24,6 +26,7 @@ import com.example.task_manager.service.IsAssignedService;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class IsAssignedServiceTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsMemberOfServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/IsMemberOfServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
 import jakarta.transaction.Transactional;
 
 import com.example.task_manager.DTO.TeamDTO;
@@ -24,6 +26,7 @@ import com.example.task_manager.service.TeamService;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class IsMemberOfServiceTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/NotificationServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/NotificationServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.example.task_manager.DTO.NotificationDTO;
 import com.example.task_manager.entity.IsAssigned;
@@ -29,6 +30,7 @@ import jakarta.transaction.Transactional;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class NotificationServiceTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TaskServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TaskServiceTest.java
@@ -2,9 +2,11 @@ package com.example.task_manager.service_tests;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public class TaskServiceTest {
 
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamMemberServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamMemberServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
 import jakarta.transaction.Transactional;
 
 import com.example.task_manager.DTO.TaskDTO;
@@ -35,6 +37,7 @@ import com.example.task_manager.service.TeamMemberService;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class TeamMemberServiceTest {
 
     @Autowired

--- a/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamServiceTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/service_tests/TeamServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import jakarta.transaction.Transactional;
 
@@ -29,6 +30,7 @@ import com.example.task_manager.service.TeamService;
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
+@ActiveProfiles("test")
 public class TeamServiceTest {
 
     @Autowired


### PR DESCRIPTION
Added annotation to each relevant test class to ensure the profile being used for testing is 'test', ensuring it is the H2 database being used when running test.
Resolves #198 