### PR TITLE
Fixing delete relationship bug

### DIFF
--- a/backend/task-manager/src/main/java/com/example/task_manager/controller/AdminController.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/controller/AdminController.java
@@ -62,8 +62,11 @@ public class AdminController {
         try {
             adminService.deleteAdmin(adminId);
             return ResponseEntity.noContent().build();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return ResponseEntity.status(404).body("Admin not found");
+        }
+        catch (Exception e) {
+            return ResponseEntity.status(500).body("Unexpected error: " + e.getMessage());
         }
     }
 

--- a/backend/task-manager/src/main/java/com/example/task_manager/entity/TeamMember.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/entity/TeamMember.java
@@ -35,6 +35,9 @@ public class TeamMember {
     @OneToMany(mappedBy = "teamMember", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<IsAssigned> assignedTasks = new HashSet<>();
 
+    @OneToMany(mappedBy = "teamMember", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Notification> notifications = new HashSet<>();
+
     public TeamMember() {}
 
     public TeamMember(String userName, String userEmail, String rawPassword) {
@@ -120,4 +123,16 @@ public class TeamMember {
         this.role = role;
     }
 
+    public Set<Notification> getNotifications() {
+        return notifications;
+    }
+
+    public void setNotifications(Set<Notification> notifications) {
+        this.notifications = notifications;
+    }
+
+    public void addNotification(Notification notification) {
+        this.notifications.add(notification);
+        notification.setTeamMember(this);
+    }    
 }

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/NotificationService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/NotificationService.java
@@ -37,6 +37,7 @@ public class NotificationService {
     private NotificationDTO createNotification(TeamMember teamMember, Task task, NotificationType type,
             String message) {
         Notification notif = new Notification(type, message, task, teamMember);
+        teamMember.addNotification(notif);
         notifRepository.save(notif);
         return convertToDTO(notif);
     }


### PR DESCRIPTION
Fixing relationship between notification and team member to be bidirectional, so deleting a team member will delete all their notifications.
Resolves #209 