### PR TITLE
Fix failing api

### DIFF
--- a/backend/task-manager/src/main/java/com/example/task_manager/repository/IsAssignedRepository.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/repository/IsAssignedRepository.java
@@ -20,4 +20,7 @@ public interface IsAssignedRepository extends JpaRepository<IsAssigned, Integer>
     Collection<IsAssigned> findByTeamMember_AccountId(int teamMemberId);
 
     Collection<IsAssigned> findByTask(Task task);
+
+    void deleteAllByTask_TaskId(int taskId);
+
 }

--- a/backend/task-manager/src/main/java/com/example/task_manager/repository/NotificationRepository.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/repository/NotificationRepository.java
@@ -17,4 +17,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Inte
 
     @Query("SELECT n FROM Notification n WHERE n.teamMember.accountId = :teamMemberId AND n.isRead = true")
     List<Notification> findByTeamMemberIdAndIsReadTrue(@Param("teamMemberId") int teamMemberId);
+
+    void deleteAllByTask_TaskId(int taskId);
+
 }

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/AdminService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/AdminService.java
@@ -31,9 +31,10 @@ public class AdminService extends TeamMemberService {
             TaskRepository taskRepository,
             IsAssignedRepository isAssignedRepository,
             AuthInfoService authInfoService,
-            NotificationService notifService) {
+            NotificationService notifService,
+            NotificationRepository notifRepository) {
         super(teamMemberRepository, teamRepository, taskRepository, isMemberOfRepository, isAssignedRepository,
-                authInfoService, notifService);
+                authInfoService, notifService, notifRepository);
         this.adminRepository = adminRepository;
     }
 

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/AdminService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/AdminService.java
@@ -266,7 +266,11 @@ public class AdminService extends TeamMemberService {
     //get all teams
     public List<TeamDTO> getAllTeams() {
         return teamRepository.findAll().stream()
-                .map(team -> new TeamDTO(team.getTeamId(), team.getTeamName(), team.getTeamLead().getAccountId()))
+                .map(team -> new TeamDTO(
+                    team.getTeamId(),
+                    team.getTeamName(),
+                    team.getTeamLead() != null ? team.getTeamLead().getAccountId() : -1 // 👈 use sentinel
+                ))
                 .collect(Collectors.toList());
     }
 

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
@@ -18,6 +18,7 @@ import com.example.task_manager.entity.Team;
 import com.example.task_manager.entity.TeamMember;
 import com.example.task_manager.repository.IsAssignedRepository;
 import com.example.task_manager.repository.IsMemberOfRepository;
+import com.example.task_manager.repository.NotificationRepository;
 import com.example.task_manager.repository.TaskRepository;
 import com.example.task_manager.repository.TeamMemberRepository;
 import com.example.task_manager.repository.TeamRepository;
@@ -33,7 +34,8 @@ public class TeamMemberService {
 	protected final TeamRepository teamRepository;
 	protected final IsMemberOfRepository isMemberOfRepository;
 	protected final TaskRepository taskRepository;
-	protected final IsAssignedRepository isAssignedRepository;
+    protected final IsAssignedRepository isAssignedRepository;
+    protected final NotificationRepository notifRepository;
 	protected final AuthInfoService authInfoService;
 	protected final NotificationService notifService;
 
@@ -44,14 +46,16 @@ public class TeamMemberService {
 							 IsMemberOfRepository isMemberOfRepository, 
 							 IsAssignedRepository isAssignedRepository,
 							 AuthInfoService authInfoService,
-							 NotificationService notifService) {
+							 NotificationService notifService,
+                             NotificationRepository notifRepository) {
 		this.teamMemberRepository = teamMemberRepository;
 		this.teamRepository = teamRepository;
 		this.isMemberOfRepository = isMemberOfRepository;
 		this.taskRepository = taskRepository;
 		this.isAssignedRepository = isAssignedRepository;
 		this.authInfoService = authInfoService;
-		this.notifService = notifService;
+        this.notifService = notifService;
+        this.notifRepository = notifRepository;
 	}
 	
 	/**
@@ -113,10 +117,10 @@ public class TeamMemberService {
 				.orElseThrow(() -> new RuntimeException("Task not found with ID: " + taskId));
 	
 		// Ensure all assignments are removed before deleting the task
-		isAssignedRepository.deleteById(taskId);
-	
-		taskRepository.delete(task);
+        isAssignedRepository.deleteAllByTask_TaskId(taskId);
+	    notifRepository.deleteAllByTask_TaskId(taskId); // 👈 add this
 
+		taskRepository.delete(task);
 	}    
 
 	/**

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/IsAssignedRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/IsAssignedRepositoryTest.java
@@ -189,7 +189,30 @@ public class IsAssignedRepositoryTest {
 
         assertNotNull(assignmentsForTask);
         assertEquals(2, assignmentsForTask.size()); // Since two team members were assigned to the task
-        assertTrue(assignmentsForTask.stream().anyMatch(a -> a.getTeamMember().getAccountId() == teamMember1.getAccountId()));
-        assertTrue(assignmentsForTask.stream().anyMatch(a -> a.getTeamMember().getAccountId() == teamMember2.getAccountId()));
+        assertTrue(assignmentsForTask.stream()
+                .anyMatch(a -> a.getTeamMember().getAccountId() == teamMember1.getAccountId()));
+        assertTrue(assignmentsForTask.stream()
+                .anyMatch(a -> a.getTeamMember().getAccountId() == teamMember2.getAccountId()));
     }
+    
+    @Test
+    void testDeleteAllAssignmentsByTaskId() {
+        Team team = createUniqueTeam();
+        Task task = createUniqueTask(team);
+
+        TeamMember member1 = createUniqueTeamMember();
+        TeamMember member2 = createUniqueTeamMember();
+
+        isAssignedRepository.save(new IsAssigned(task, member1, team));
+        isAssignedRepository.save(new IsAssigned(task, member2, team));
+
+        Collection<IsAssigned> assignmentsBefore = isAssignedRepository.findByTask(task);
+        assertEquals(2, assignmentsBefore.size());
+
+        isAssignedRepository.deleteAllByTask_TaskId(task.getTaskId());
+
+        Collection<IsAssigned> assignmentsAfter = isAssignedRepository.findByTask(task);
+        assertEquals(0, assignmentsAfter.size());
+    }
+
 }

--- a/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/NotificationRepositoryTest.java
+++ b/backend/task-manager/src/test/java/com/example/task_manager/repository_tests/NotificationRepositoryTest.java
@@ -155,4 +155,25 @@ public class NotificationRepositoryTest {
         assertNotNull(notifs);
         assertEquals(0, notifs.size());
     }
+
+    @Test
+    void testDeleteAllNotificationsByTaskId() {
+        Team team = createUniqueTeam();
+        TeamMember member = createUniqueTeamMember();
+        Task task = createUniqueTask(team);
+
+        Notification n1 = new Notification(NotificationType.TASK_ASSIGNED, "Assigned", task, member);
+        Notification n2 = new Notification(NotificationType.TASK_UNASSIGNED, "Unassigned", task, member);
+        notificationRepository.save(n1);
+        notificationRepository.save(n2);
+
+        List<Notification> found = notificationRepository.findAll();
+        assertEquals(2, found.size());
+
+        notificationRepository.deleteAllByTask_TaskId(task.getTaskId());
+
+        List<Notification> remaining = notificationRepository.findAll();
+        assertEquals(0, remaining.size());
+    }
+
 }


### PR DESCRIPTION
Fixed the failing API methods getAllTeams in AdminService and deleteTask in TeamMemberService. 

For getAllTeams, if a teamLead is null it will return -1 now.

For deleteTask, all notifications related to the task and all IsAssignedTo relationships will be dleeted when the task is deleted.