### PR TITLE
teamLead can be null for getMembers of a team

### DIFF
--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamService.java
@@ -110,7 +110,7 @@ public class TeamService {
 		Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new RuntimeException("Team not found with ID: " + teamId));
 
-        int teamLeadId = team.getTeamLead().getAccountId();
+        int teamLeadId = (team.getTeamLead() != null) ? team.getTeamLead().getAccountId() : -1;
 
 		return isMemberOfRepository.findMembersByTeamId(teamId).stream()
                 .map(isMember -> {


### PR DESCRIPTION
Allowing team emmebrs to be returned for a team when teamLead if null.