### PR TITLE
Changed logo href

### DIFF
--- a/frontend/react-app/src/components/Header.jsx
+++ b/frontend/react-app/src/components/Header.jsx
@@ -5,7 +5,7 @@ function Header(){
             
                 <h1 className ="inHeader">
                         <ul className ='list'>
-                            <li className ="logo list"><span><a href="#">Whatever we Call this</a></span></li>
+                            <li className ="logo list"><span><a href="/home">Whatever we Call this</a></span></li>
                             <li><span><a href="/home">Home</a></span></li>
                             <li><span><a href="/my-tasks">Tasks</a></span></li>
                             <li><span><a href="/profile">Profile</a></span></li>


### PR DESCRIPTION
State pages no longer crash when you click on the logo. Resolves #244 