### PR TITLE
Fix isAdmin to return role

### DIFF
--- a/frontend/react-app/src/api/authInfoApi.js
+++ b/frontend/react-app/src/api/authInfoApi.js
@@ -26,11 +26,10 @@ export const login = async (accountId, password) => {
 export const isAdmin = async (teamMemberId) => {
     try {
         const response = await fetch(`${BASE_URL}/${teamMemberId}/is-admin`, {
-            method: 'POST',
+            method: 'GET',
             headers: {
                 "Content-Type": "application/json"
             },
-            body: JSON.stringify({teamMemberId})
         });
 
         if (!response.ok) {
@@ -38,8 +37,8 @@ export const isAdmin = async (teamMemberId) => {
             return false;
         }
 
-        const data = await response.json();
-        return data.isAdmin === true;
+        const role = await response.json();
+        return role;
     }
     catch (error) {
         console.error("Error checking member role: ", error);

--- a/frontend/react-app/src/tests/api-tests/authInfoApiTest.test.js
+++ b/frontend/react-app/src/tests/api-tests/authInfoApiTest.test.js
@@ -30,31 +30,29 @@ describe('AuthInfo API', () => {
 
     //test: check if user is an admin
     test('isAdmin should return true when user is an admin', async () => {
-        fetch.mockResponseOnce(JSON.stringify({ isAdmin: true }), { status: 200 });
+        fetch.mockResponseOnce(JSON.stringify("ADMIN"), { status: 200 });
 
         const response = await isAdmin(1);
 
         expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/1/is-admin`, {
-            method: 'POST',
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ teamMemberId: 1 })
+            method: 'GET',
+            headers: { "Content-Type": "application/json" }
         });
 
-        expect(response).toBe(true);
+        expect(response).toBe("ADMIN");
     });
 
     //test: check if user is not an admin
     test('isAdmin should return false when user is not an admin', async () => {
-        fetch.mockResponseOnce(JSON.stringify({ isAdmin: false }), { status: 200 });
+        fetch.mockResponseOnce(JSON.stringify("TEAM_MEMBER"), { status: 200 });
 
         const response = await isAdmin(1);
 
         expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/1/is-admin`, {
-            method: 'POST',
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ teamMemberId: 1 })
+            method: 'GET',
+            headers: { "Content-Type": "application/json" }
         });
 
-        expect(response).toBe(false);
+        expect(response).toBe("TEAM_MEMBER");
     });
 });


### PR DESCRIPTION
Chaning isAdmin to return the role instead of a boolean, to match the frontend and the documentation. Resolves #282