### PR TITLE
Fewer notifs

### DIFF
--- a/backend/task-manager/src/main/java/com/example/task_manager/service/NotificationService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/NotificationService.java
@@ -52,7 +52,7 @@ public class NotificationService {
                 teamMember,
                 updatedTask,
                 NotificationType.TASK_TITLE_EDITED,
-                "Task Update: The title of a task was changed from \"" + oldTitle + "\" to \"" + updatedTask.getTitle() + "\""
+                "Task Update: The title of a task was changed from \"" + oldTitle + "\" to \"" + updatedTask.getTitle() + "\" on " + LocalDate.now()
             );
         }
     }
@@ -67,7 +67,7 @@ public class NotificationService {
                 teamMember,
                 updatedTask,
                 NotificationType.TASK_DESCRIPTION_EDITED,
-                "Task Update: The description of a task was changed from \"" + oldDescription + "\" to \"" + updatedTask.getDescription() + "\""
+                "Task Update: The description of a task was changed from \"" + oldDescription + "\" to \"" + updatedTask.getDescription() + "\" on " + LocalDate.now()
             );
         }
     }
@@ -82,7 +82,7 @@ public class NotificationService {
                 teamMember,
                 updatedTask,
                 NotificationType.TASK_LOCK_STATUS_CHANGED,
-                "Task Update: The lock status of a task was changed from \"" + oldLockStatus + "\" to \"" + updatedTask.isLocked() + "\""
+                "Task Update: The lock status of a task was changed from \"" + oldLockStatus + "\" to \"" + updatedTask.isLocked() + "\" on " + LocalDate.now()
             );
         }
     }
@@ -98,7 +98,7 @@ public class NotificationService {
                     updatedTask,
                     NotificationType.TASK_DUE_DATE_EDITED,
                     "Task Update: The due date of a task was changed from \"" + oldDueDate + "\" to \"" + updatedTask.getDueDate()
-                            + "\"");
+                            + "\" on " + LocalDate.now());
         }
     }
     
@@ -112,7 +112,7 @@ public class NotificationService {
                 teamMember,
                 updatedTask,
                 NotificationType.TASK_STATUS_EDITED,
-                "Task Update: The status of a task was changed from \"" + oldStatus + "\" to \"" + updatedTask.getStatus() + "\""
+                "Task Update: The status of a task was changed from \"" + oldStatus + "\" to \"" + updatedTask.getStatus() + "\" on " + LocalDate.now()
             );
         }
     }
@@ -120,19 +120,19 @@ public class NotificationService {
     //notify member when task is assigned
     public void notifyTaskAssignment(TeamMember teamMember, Task task) {
         createNotification(teamMember, task, NotificationType.TASK_ASSIGNED,
-                "You have been assigned to a task: \"" + task.getTitle());
+                "You have been assigned to a task: \"" + task.getTitle() + "\" on " + LocalDate.now());
     }
     
     //notify member when task is unassigned
     public void notifyTaskUnassignment(TeamMember teamMember, Task task) {
         createNotification(teamMember, task, NotificationType.TASK_UNASSIGNED,
-                "You have been unassigned from a task: \"" + task.getTitle());
+                "You have been unassigned from a task: \"" + task.getTitle() + "\" on " + LocalDate.now());
     }
 
     //notify member when they are added to a team
     public void notifyTeamAssignment(TeamMember teamMember, Team team) {
         createNotification(teamMember, null, NotificationType.TEAM_ASSIGNED,
-                "You have been assigned to a team: \"" + team.getTeamName());
+                "You have been assigned to a team: \"" + team.getTeamName() + "\" on " + LocalDate.now());
     }
     
     //notify member when they are removed from a team

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
@@ -146,13 +146,6 @@ public class TeamMemberService {
 		String oldStatus = task.getStatus();
 		LocalDate oldDueDate = task.getDueDate();
 
-		// if (taskDTO.getTitle() == oldTitle &&
-		//     taskDTO.getDescription() == oldDescription &&
-		// 	taskDTO.getIsLocked() == oldLockStatus && 
-		// 	taskDTO.getDueDate() == oldDueDate &&
-		// 	taskDTO.getStatus() == oldStatus){
-		// 		//nothing has been changed
-		// }
 		if ((taskDTO.getTitle() != null && !taskDTO.getTitle().isEmpty()) &&
 			(!taskDTO.getTitle().equals(oldTitle))) {
 			task.setTitle(taskDTO.getTitle());

--- a/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
+++ b/backend/task-manager/src/main/java/com/example/task_manager/service/TeamMemberService.java
@@ -146,14 +146,23 @@ public class TeamMemberService {
 		String oldStatus = task.getStatus();
 		LocalDate oldDueDate = task.getDueDate();
 
-		if (taskDTO.getTitle() != null && !taskDTO.getTitle().isEmpty()) {
+		// if (taskDTO.getTitle() == oldTitle &&
+		//     taskDTO.getDescription() == oldDescription &&
+		// 	taskDTO.getIsLocked() == oldLockStatus && 
+		// 	taskDTO.getDueDate() == oldDueDate &&
+		// 	taskDTO.getStatus() == oldStatus){
+		// 		//nothing has been changed
+		// }
+		if ((taskDTO.getTitle() != null && !taskDTO.getTitle().isEmpty()) &&
+			(!taskDTO.getTitle().equals(oldTitle))) {
 			task.setTitle(taskDTO.getTitle());
 
 			//call notif method
 			notifService.notifyTaskTitleChange(task, oldTitle);
 		}
 
-		if (taskDTO.getDescription() != null && !taskDTO.getDescription().isEmpty()) {
+		if (taskDTO.getDescription() != null && !taskDTO.getDescription().isEmpty()&&
+			(!taskDTO.getDescription().equals(oldDescription))) {
 			task.setDescription(taskDTO.getDescription());
 
 			//call notif method
@@ -174,7 +183,7 @@ public class TeamMemberService {
 			notifService.notifyTaskStatusChange(task, oldStatus);
 		}
 
-		if (taskDTO.getDueDate() != null) {
+		if (taskDTO.getDueDate() != null && !taskDTO.getDueDate().equals(oldDueDate)) {
 			task.setDueDate(taskDTO.getDueDate());
 
 			//call notif method

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -1,14 +1,13 @@
 #notifContainer {
     background-color: white;
-    width: 600px;
+    width: 1300px;
     height: 500px;
     margin: auto;
+    padding: 2%;
     font-family: Arial, Helvetica, sans-serif;
 }
 
-#notifContainer table {
-    width: 100%;
-}
+
 
 #notifContainer thead td {
     width: 100%;

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -1,12 +1,15 @@
 #notifContainer {
     background-color: white;
-    width: 40%;
+    width: 1300px;
     height: 500px;
     margin: auto;
     padding: 2%;
     font-family: Arial, Helvetica, sans-serif;
 }
 
+#notifContainer table {
+    width: 100%;
+}
 
 
 #notifContainer thead td {
@@ -42,11 +45,14 @@
     background-color: #52799d;
 }
 
+.delete{
+
+}
+
 .delete:hover {
     cursor: pointer;
     color: white;
     background-color: red;
-    border: none;
 }
 
 .smallTeamButton {

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -13,7 +13,7 @@
 #notifContainer thead td {
     width: 100%;
     color: white;
-    background-color: #254E58;
+    background-color: #52799d;
 }
 
 /* #notifContainer tbody td { */

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -1,6 +1,6 @@
 #notifContainer {
     background-color: white;
-    width: 1300px;
+    width: 40%;
     height: 500px;
     margin: auto;
     padding: 2%;

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -28,10 +28,6 @@
     text-align: left !important;
 }
 
-#notifContainer tbody td {
-    background-color: white;
-}
-
 #notifContainer input {
     border: none;
 }
@@ -43,10 +39,8 @@
 .subHeader {
     text-align: left !important;
     padding-left: 10px;
-}
-
-.delete {
-
+    color: white;
+    background-color: #52799d;
 }
 
 .delete:hover {
@@ -68,3 +62,4 @@
     background-color: black;
 
 }
+

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -1,6 +1,6 @@
 #notifContainer {
-    background-color: white;
-    width: 600px;
+    background-color: white;;
+    width: 75%;
     height: 500px;
     margin: left;
     padding: 2%;
@@ -8,7 +8,7 @@
 }
 
 #notifContainer table {
-    width: 100%;
+    width: 130%;
 }
 
 
@@ -53,6 +53,7 @@
     cursor: pointer;
     color: white;
     background-color: red;
+    border: none;
 }
 
 .smallTeamButton {
@@ -68,3 +69,12 @@
 
 }
 
+
+.notifBox {
+    width: 75%;
+    
+}
+
+.column-box {
+    width: 120%;
+}

--- a/frontend/react-app/src/css/Notifications.css
+++ b/frontend/react-app/src/css/Notifications.css
@@ -1,8 +1,8 @@
 #notifContainer {
     background-color: white;
-    width: 1300px;
+    width: 600px;
     height: 500px;
-    margin: auto;
+    margin: left;
     padding: 2%;
     font-family: Arial, Helvetica, sans-serif;
 }

--- a/frontend/react-app/src/pages/Notifications.jsx
+++ b/frontend/react-app/src/pages/Notifications.jsx
@@ -109,7 +109,6 @@ const Notifications = () => {
         <div className='pageContainer'>
             <Header/>
             <div className='pageBody'>
-                <div></div>
             <div id="notifContainer">
                 <div className="column-box">
                     <h2>My Notifications</h2>

--- a/frontend/react-app/src/pages/Notifications.jsx
+++ b/frontend/react-app/src/pages/Notifications.jsx
@@ -109,15 +109,13 @@ const Notifications = () => {
         <div className='pageContainer'>
             <Header/>
             <div className='pageBody'>
+                <div></div>
             <div id="notifContainer">
                 <div className="column-box">
                     <h2>My Notifications</h2>
                         <div className="section-divider"></div>
                         <div className ="notifBox">
                         <table>
-                            <thead>
-
-                            </thead>
                             <tbody>
                                 <NotificationSection title="Unread" items={memoizedUnReadNotifications} />
                                 <NotificationSection title="Read" items={memoizedReadNotifications} />

--- a/frontend/react-app/src/pages/Notifications.jsx
+++ b/frontend/react-app/src/pages/Notifications.jsx
@@ -111,95 +111,26 @@ const Notifications = () => {
             <div className='pageBody'>
             <div id="notifContainer">
                 <div className="column-box">
-                    <h2>My Completed Tasks</h2>
+                    <h2>My Notifications</h2>
                         <div className="section-divider"></div>
-                        <div className ="taskBox">
-                           
-                                <h2>No tasks completed</h2>
-                                
+                        <div className ="notifBox">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <td colSpan="4">Notifications</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <NotificationSection title="Unread" items={memoizedUnReadNotifications} />
+                                <NotificationSection title="Read" items={memoizedReadNotifications} />
+                            </tbody>
+                        </table>
                         </div>
-                    </div>
-            <table>
-                <thead>
-                    <tr>
-                        <td colSpan="4">Notifications</td>
-                    </tr>
-                </thead>
-                <tbody>
-                    <NotificationSection title="Unread" items={memoizedUnReadNotifications} />
-                    <NotificationSection title="Read" items={memoizedReadNotifications} />
-                </tbody>
-            </table>
-        </div>
+                </div>   
+            </div>
             </div>
         </div>
     );
 };
 
 export default Notifications;
-
-
-//before refactoring 
-
-
-// import React from 'react';
-// import {useEffect, useState} from 'react';
-// import '../css/Notifications.css';
-// import Notification from "../components/Notification";
-
-// const Notifications = () => {
-//     const [notifications, setNotifications] = useState([
-//         {id: 1, team: "Team 2", message: 'Bob edited your task "Create wireframe"', read: false},
-//         { id: 2, team: "Team 1", message: 'Mary completed your task "Code things"', read: false },
-//         { id: 3, team: "Team 1", message: 'Adam assigned you to "Code more"', read: true }
-//     ]);
-
-//     //mark as read or unread
-//     const toggleRead = (id) => {
-//         setNotifications(notifications.map(notif =>
-//             notif.id === id ? { ...notif, read: !notif.read } : notif
-//         ));
-//     };
-
-//     //delete any notification
-//     const deleteNotification = (id) => {
-//         setNotifications(notifications.filter(notif => notif.id !== id));
-//     };
-
-//     return (
-//         <div id="notifContainer">
-//            <table>
-//                 <thead>
-//                     <tr>
-//                         <td colSpan="4">Notifications</td>
-//                     </tr>
-//                 </thead>
-//                 <tbody>
-//                     {notifications.some(notif => !notif.read) && (
-//                         <>
-//                             <tr>
-//                                 <td colSpan="4" className="subHeader">Unread</td>
-//                             </tr>
-//                             {notifications.filter(notif => !notif.read).map(notif => (
-//                                 <Notification key={notif.id} notif={notif} toggleRead={toggleRead} deleteNotification={deleteNotification} />
-//                             ))}
-//                         </>
-//                     )}
-
-//                     {notifications.some(notif => notif.read) && (
-//                         <>
-//                             <tr>
-//                                 <td colSpan="4" className="subHeader">Read</td>
-//                             </tr>
-//                             {notifications.filter(notif => notif.read).map(notif => (
-//                                 <Notification key={notif.id} notif={notif} toggleRead={toggleRead} deleteNotification={deleteNotification} />
-//                             ))}
-//                         </>
-//                     )}
-//                 </tbody>
-//             </table>
-//         </div>
-//     )
-// }
-
-// export default Notifications;

--- a/frontend/react-app/src/pages/Notifications.jsx
+++ b/frontend/react-app/src/pages/Notifications.jsx
@@ -1,3 +1,4 @@
+import TaskList from "../components/TaskList";
 import React, { useEffect, useMemo, useState } from 'react';
 import '../css/Notifications.css';
 import Notification from "../components/Notification";
@@ -84,6 +85,7 @@ const Notifications = () => {
     // reusable section component
     const NotificationSection = ({ title, items }) => (
         items.length > 0 && (
+            
             <>
                 <tr>
                     <td colSpan="4" className="subHeader">{title}</td>
@@ -96,6 +98,7 @@ const Notifications = () => {
                         deleteNotification={deleteNotification} 
                     />
                 ))}
+                    
             </>
         )
     );
@@ -107,6 +110,15 @@ const Notifications = () => {
             <Header/>
             <div className='pageBody'>
             <div id="notifContainer">
+                <div className="column-box">
+                    <h2>My Completed Tasks</h2>
+                        <div className="section-divider"></div>
+                        <div className ="taskBox">
+                           
+                                <h2>No tasks completed</h2>
+                                
+                        </div>
+                    </div>
             <table>
                 <thead>
                     <tr>

--- a/frontend/react-app/src/pages/Notifications.jsx
+++ b/frontend/react-app/src/pages/Notifications.jsx
@@ -116,9 +116,7 @@ const Notifications = () => {
                         <div className ="notifBox">
                         <table>
                             <thead>
-                                <tr>
-                                    <td colSpan="4">Notifications</td>
-                                </tr>
+
                             </thead>
                             <tbody>
                                 <NotificationSection title="Unread" items={memoizedUnReadNotifications} />


### PR DESCRIPTION
Adds the purple background box and title that all other pages have. Made the 'read' and 'unread' header rows stand out more and have background that matches the other pages. Users no longer receive notifications for irrelevant changes such as "changed task name from 'TASK1' to 'TASK1'. Notifications now include the time they were sent. Resolves #319, #313, #312, and #310.